### PR TITLE
fix: make auth token a password field

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -323,7 +323,8 @@ class SettingTab extends PluginSettingTab {
 				.onChange(async (value) => {
 					this.plugin.settings.paperlessAuthToken = value;
 					await this.plugin.saveSettings();
-				}));
+				})
+				.inputEl.type = 'password');
 		new Setting(containerEl)
 			.setName('Document storage path')
 			.setDesc('Location for stored documents.')


### PR DESCRIPTION
currently the auth Token field is a normal text field - imho it should be a password field as its a credential.