### PR TITLE
feat: replace url at cursor (no need to select)

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -150,7 +150,7 @@ function parsePaperlessUrlAtCursor(editor: Editor, settings: PluginSettings): Pa
 
 		// find documentId in the selection using a regex
 		const normalizedUrl = new URL(settings.paperlessUrl);
-		const quotedUrl = escapeRegExp(normalizedUrl);
+		const quotedUrl = escapeRegExp(normalizedUrl.toString());
 		const regex = quotedUrl +
 			"(?:" +
 			"api/documents/(?<documentId>\\d+)/preview" +

--- a/main.ts
+++ b/main.ts
@@ -31,7 +31,7 @@ export default class ObsidianPaperless extends Plugin {
 			id: 'replace-with-paperless',
 			name: 'Replace URL with document',
 			editorCallback: (editor: Editor) => {
-				const paperlessUrl = parsePaperlessUrlAtCursor(editor, this.settings);
+				const paperlessUrl = searchPaperlessUrl(editor, this.settings);
 				if (paperlessUrl) {
 					createDocument(editor, this.settings, paperlessUrl);
 				}
@@ -138,37 +138,37 @@ interface PaperlessUrl {
 	range: EditorRange;
 }
 
-/// Parse the Paperless URL from the cursor position
-function parsePaperlessUrlAtCursor(editor: Editor, settings: PluginSettings): PaperlessUrl | null {
-	try {
-		const wordRange = wordAtCursor(editor);
-		if (wordRange === null) {
-			return null;
-		}
-
-		const text = editor.getRange(wordRange.from, wordRange.to)
-
-		// find documentId in the selection using a regex
-		const normalizedUrl = new URL(settings.paperlessUrl);
-		const quotedUrl = escapeRegExp(normalizedUrl.toString());
-		const regex = quotedUrl +
-			"(?:" +
-			"api/documents/(?<documentId>\\d+)/preview" +
-			"|documents/(?<documentId>\\d+)/details" +
-			")";
-
-		const match = text.match(regex);
-		if (!match || !match.groups) {
-			return null;
-		}
-
-		return {
-			documentId: match.groups.documentId,
-			range: wordRange
-		};
-	} catch {
+/// Search the Paperless URL from selection / cursor position
+function searchPaperlessUrl(editor: Editor, settings: PluginSettings): PaperlessUrl | null {
+	const wordRange = wordAtCursor(editor);
+	if (wordRange === null) {
 		return null;
 	}
+
+	const text = editor.getRange(wordRange.from, wordRange.to)
+
+	// find documentId in the selection using a regex
+	const normalizedUrl = new URL(settings.paperlessUrl).toString();
+	const quotedUrl = escapeRegExp(normalizedUrl);
+	const urlVariants = [
+		`${quotedUrl}api/documents/(\\d+)/preview`,
+		`${quotedUrl}documents/(\\d+)/details`
+	];
+
+	// find a matching URL variant
+	for (const regex of urlVariants) {
+		console.log("Regex: " + regex);
+		const match = text.match(regex);
+		if (match) {
+			return {
+				documentId: match[1],
+				range: wordRange
+			};
+		}
+	}
+
+	// nothing found
+	return null;
 }
 
 async function getExistingShareLink(settings: PluginSettings, documentId: string) {

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,5 @@
-import { App, Editor, MarkdownView, Modal, normalizePath, Notice, Plugin, PluginSettingTab, requestUrl, RequestUrlResponse, Setting, setIcon, TFolder, TFile } from 'obsidian';
+import { App, Editor, EditorRange, MarkdownView, Modal, normalizePath, Notice, Plugin, PluginSettingTab, requestUrl, RequestUrlResponse, Setting, setIcon, TFolder, TFile } from 'obsidian';
+import { escapeRegExp } from 'lodash';
 
 interface PluginSettings {
 	paperlessUrl: string;
@@ -30,9 +31,9 @@ export default class ObsidianPaperless extends Plugin {
 			id: 'replace-with-paperless',
 			name: 'Replace URL with document',
 			editorCallback: (editor: Editor) => {
-				const documentId = extractDocumentIdFromUrl(editor, this.settings);
-				if (documentId) {
-					createDocument(editor, this.settings, documentId);
+				const paperlessUrl = parsePaperlessUrlAtCursor(editor, this.settings);
+				if (paperlessUrl) {
+					createDocument(editor, this.settings, paperlessUrl);
 				}
 			}
 		});
@@ -110,11 +111,61 @@ async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) 
 	}
 }
 
-function extractDocumentIdFromUrl(editor: Editor, settings: PluginSettings) {
+/// Find the word under the cursor (we can't use editor.wordAt because we want everything between two whitespace characters)
+function wordAtCursor(editor: Editor): EditorRange | null {
+	const cursor = editor.getCursor();
+	const line = editor.getLine(cursor.line);
+
+	const wordRegex = /\S+/g;
+	let match: RegExpExecArray | null;
+
+	while ((match = wordRegex.exec(line)) !== null) {
+		const start = match.index;
+		const end = start + match[0].length;
+		if (cursor.ch >= start && cursor.ch <= end) {
+			return {
+				from: { line: cursor.line, ch: start },
+				to: { line: cursor.line, ch: end }
+			};
+		}
+	}
+
+	return null;
+}
+
+interface PaperlessUrl {
+	documentId: string;
+	range: EditorRange;
+}
+
+/// Parse the Paperless URL from the cursor position
+function parsePaperlessUrlAtCursor(editor: Editor, settings: PluginSettings): PaperlessUrl | null {
 	try {
-		const selection = editor.getSelection();
-		const documentId = selection.split('api/documents/')[1].split('/preview')[0];
-		return documentId;
+		const wordRange = wordAtCursor(editor);
+		if (wordRange === null) {
+			return null;
+		}
+
+		const text = editor.getRange(wordRange.from, wordRange.to)
+
+		// find documentId in the selection using a regex
+		const normalizedUrl = new URL(settings.paperlessUrl);
+		const quotedUrl = escapeRegExp(normalizedUrl);
+		const regex = quotedUrl +
+			"(?:" +
+			"api/documents/(?<documentId>\\d+)/preview" +
+			"|documents/(?<documentId>\\d+)/details" +
+			")";
+
+		const match = text.match(regex);
+		if (!match || !match.groups) {
+			return null;
+		}
+
+		return {
+			documentId: match.groups.documentId,
+			range: wordRange
+		};
 	} catch {
 		return null;
 	}
@@ -187,7 +238,7 @@ async function getShareLink(settings: PluginSettings, documentId: string) {
 }
 
 // Heavily inspired by https://github.com/RyotaUshio/obsidian-pdf-plus/blob/127ea5b94bb8f8fa0d4c66bcd77b3809caa50b21/src/modals/external-pdf-modals.ts#L249
-async function createDocument(editor: Editor, settings: PluginSettings, documentId: string) {
+async function createDocument(editor: Editor, settings: PluginSettings, paperlessUrl: PaperlessUrl) {
 	// Create the parent folder
 	const folderPath = normalizePath(settings.documentStoragePath);
 	if (folderPath) {
@@ -198,17 +249,17 @@ async function createDocument(editor: Editor, settings: PluginSettings, document
 		}
 	}
 	
-	const filename = 'paperless-' + documentId + '.pdf';
+	const filename = 'paperless-' + paperlessUrl.documentId + '.pdf';
 	const fileRef = this.app.vault.getAbstractFileByPath(folderPath + '/' + filename); 
 	const fileExists = !!(fileRef) && fileRef instanceof TFile;
 	if (!fileExists) {
-		const shareLink = await getShareLink(settings, documentId);
+		const shareLink = await getShareLink(settings, paperlessUrl.documentId);
 		if (shareLink) {
 			await this.app.vault.create(folderPath + '/' + filename, shareLink.href);
 		}
 	}
 
-	editor.replaceSelection('![[' + filename + ']]');
+	editor.replaceRange('![[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
 }
 
 class DocumentSelectorModal extends Modal {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "obsidian-sample-plugin",
 			"version": "1.0.0",
 			"license": "MIT",
+			"dependencies": {
+				"lodash": "^4.17.21"
+			},
 			"devDependencies": {
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
@@ -1777,6 +1780,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,14 @@
 			"name": "obsidian-sample-plugin",
 			"version": "1.0.0",
 			"license": "MIT",
-			"dependencies": {
-				"lodash": "^4.17.21"
-			},
 			"devDependencies": {
+				"@types/lodash": "^4.17.16",
 				"@types/node": "^16.11.6",
 				"@typescript-eslint/eslint-plugin": "5.29.0",
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.17.3",
+				"lodash": "^4.17.21",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
@@ -581,6 +580,13 @@
 			"version": "7.0.15",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/lodash": {
+			"version": "4.17.16",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+			"integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1785,6 +1791,7 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
 			"name": "obsidian-sample-plugin",
 			"version": "1.0.0",
 			"license": "MIT",
+			"dependencies": {
+				"lodash": "^4.17.21"
+			},
 			"devDependencies": {
 				"@types/lodash": "^4.17.16",
 				"@types/node": "^16.11.6",
@@ -15,7 +18,6 @@
 				"@typescript-eslint/parser": "5.29.0",
 				"builtin-modules": "3.3.0",
 				"esbuild": "0.17.3",
-				"lodash": "^4.17.21",
 				"obsidian": "latest",
 				"tslib": "2.4.0",
 				"typescript": "4.7.4"
@@ -1791,7 +1793,6 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
+	},
+	"dependencies": {
+		"lodash": "^4.17.21"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
+	},
+	"dependencies": {
+		"lodash": "^4.17.21"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 	"author": "",
 	"license": "MIT",
 	"devDependencies": {
+		"@types/lodash": "^4.17.16",
 		"@types/node": "^16.11.6",
 		"@typescript-eslint/eslint-plugin": "5.29.0",
 		"@typescript-eslint/parser": "5.29.0",
@@ -20,8 +21,5 @@
 		"obsidian": "latest",
 		"tslib": "2.4.0",
 		"typescript": "4.7.4"
-	},
-	"dependencies": {
-		"lodash": "^4.17.21"
 	}
 }


### PR DESCRIPTION
This PR changes the behaviour of `Paperless: Replace URL with Document`: The command now works with the cursor position instead of a selection. Furthermore it adds parsing of `/documents/:id/details` urls as well. (with simple way of adding more urls later on)