### PR TITLE
Add Option to insert paperless document links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,20 @@ This plugin allows users to easily insert PDFs from their self-hosted paperless-
 
 ## Features
 
-- View all documents on your paperless-ngx instance from within the comfort of your Obsidian vault.
-- One-click insertion of one or many documents into your vault.
-- Reduce vault size by using this plugin to remotely reference PDFs within your paperless-ngx instance.
+-   View all documents on your paperless-ngx instance from within the comfort of your Obsidian vault.
+-   One-click insertion of one or many documents into your vault.
+-   Reduce vault size by using this plugin to remotely reference PDFs within your paperless-ngx instance.
+-   Insert document links with thumbnail preview.
 
-## Prerequisites 
-This assumes you have a working version of [paperless-ngx](https://github.com/paperless-ngx/paperless-ngx) hosted. It does not necessarily need to be remotely accessible. This decision is left up to the reader. 
+## Prerequisites
+
+This assumes you have a working version of [paperless-ngx](https://github.com/paperless-ngx/paperless-ngx) hosted. It does not necessarily need to be remotely accessible. This decision is left up to the reader.
 
 You must also have the ✨amazing✨ [PDF++](https://github.com/RyotaUshio/obsidian-pdf-plus) plugin installed!
 
 ## How it works
-This plugin interacts with your paperless instance to enable seamless viewing of your documents within Obsidian. When you click on a document to import it will generate a share link from paperless and embed it into a *external PDF file*. Read more [here](https://ryotaushio.github.io/obsidian-pdf-plus/external-pdf-files.html). You can now view that document as though it was natively loaded in your vault, without needing to worry about local or remote storage limits.
+
+This plugin interacts with your paperless instance to enable seamless viewing of your documents within Obsidian. When you click on a document to import it will generate a share link from paperless and embed it into a _external PDF file_. Read more [here](https://ryotaushio.github.io/obsidian-pdf-plus/external-pdf-files.html). You can now view that document as though it was natively loaded in your vault, without needing to worry about local or remote storage limits.
 
 ## Setup
 
@@ -30,26 +33,42 @@ This plugin interacts with your paperless instance to enable seamless viewing of
     - Paperless URL: full url to your paperless-ngx instance. Do not include the trailing `/`.
     - Paperless authentication token: token you obtained in step 1.
     - Document storage path: location you would like to save references to these PDFs.
-5. Click "Test connection" to confirm connectivity. If any errors appear, you can view them in the console. Open the console using `cmd+option+i` (MacOS) or `ctrl+shift+i` (Windows). 
+    - Thumbnail storage path: location for document thumbnail images.
+5. Click "Test connection" to confirm connectivity. If any errors appear, you can view them in the console. Open the console using `cmd+option+i` (MacOS) or `ctrl+shift+i` (Windows).
 
 ## Usage
 
 ### Basic usage
+
 1. Go to the note you want to insert a document into. The editor view must be in focus.
 1. Open the command palette in Obsidian (ctrl/cmd + p or swipe down on mobile).
 1. Search "Paperless".
 1. Select `Paperless: Insert document`. Click on the document(s) you want to insert.
 
 ### Available Commands
+
 The following commands are available for use.
 
 #### Insert document
-The standard insertion command. Please note you must have an open editor focused to use this command. Brings up the document selection modal.
+
+The standard insertion command. Please note you must have an open editor focused to use this command. Brings up the document selection modal and embeds the full PDF into your note.
+
+#### Insert document link
+
+Inserts a clickable link to the document. After selecting a document, you can choose between:
+
+-   **With Thumbnail**: Creates a link with a thumbnail preview. The thumbnail is stored locally as an image.
+-   **Text Link Only**: Creates a simple text link to the document without any preview image.
+
+The document itself remains on your paperless instance. This is useful if you want to reference documents without embedding the full PDF.
 
 #### Refresh document cache
+
 The "Insert document" command caches some information such as available documents, tags, and other metadata when it is first run. If you find that new documents or changes are not showing up in the document selection modal, running this command will refresh the caches.
 
 #### Replace URL with document
+
 This command replaces a url in a note with an embed of the document. To use:
+
 1. Move your cursor onto a paperless url in a note. The url should be of the form `http://ip:port/api/documents/id/preview/` or `http://ip:port/documents/id/details`
 1. Run this command

--- a/main.ts
+++ b/main.ts
@@ -1,10 +1,27 @@
-import { App, Editor, EditorRange, MarkdownView, Modal, normalizePath, Notice, Plugin, PluginSettingTab, requestUrl, RequestUrlResponse, Setting, setIcon, TFolder, TFile } from 'obsidian';
-import { escapeRegExp } from 'lodash';
+import {
+	App,
+	Editor,
+	EditorRange,
+	MarkdownView,
+	Modal,
+	normalizePath,
+	Notice,
+	Plugin,
+	PluginSettingTab,
+	requestUrl,
+	RequestUrlResponse,
+	Setting,
+	setIcon,
+	TFolder,
+	TFile,
+} from "obsidian";
+import { escapeRegExp } from "lodash";
 
 interface PluginSettings {
 	paperlessUrl: string;
 	paperlessAuthToken: string;
 	documentStoragePath: string;
+	thumbnailStoragePath: string;
 }
 
 interface PaperlessInsertionData {
@@ -13,10 +30,11 @@ interface PaperlessInsertionData {
 }
 
 const DEFAULT_SETTINGS: PluginSettings = {
-	paperlessUrl: '',
-	paperlessAuthToken: '',
-	documentStoragePath: ''
-}
+	paperlessUrl: "",
+	paperlessAuthToken: "",
+	documentStoragePath: "",
+	thumbnailStoragePath: "paperless-thumbnails",
+};
 
 export default class ObsidianPaperless extends Plugin {
 	settings: PluginSettings;
@@ -25,31 +43,49 @@ export default class ObsidianPaperless extends Plugin {
 		await this.loadSettings();
 
 		this.addCommand({
-			id: 'insert-from-paperless',
-			name: 'Insert document',
+			id: "insert-from-paperless",
+			name: "Insert document",
 			editorCallback: (editor: Editor) => {
-				new DocumentSelectorModal(this.app, editor, this.settings).open();
-			}
+				new DocumentSelectorModal(
+					this.app,
+					editor,
+					this.settings,
+					"embed"
+				).open();
+			},
 		});
 
 		this.addCommand({
-			id: 'replace-with-paperless',
-			name: 'Replace URL with document',
+			id: "insert-link-from-paperless",
+			name: "Insert document link",
+			editorCallback: (editor: Editor) => {
+				new DocumentSelectorModal(
+					this.app,
+					editor,
+					this.settings,
+					"link"
+				).open();
+			},
+		});
+
+		this.addCommand({
+			id: "replace-with-paperless",
+			name: "Replace URL with document",
 			editorCallback: (editor: Editor) => {
 				const paperlessUrl = searchPaperlessUrl(editor, this.settings);
 				if (paperlessUrl) {
 					createDocument(editor, this.settings, paperlessUrl);
 				}
-			}
+			},
 		});
 
 		this.addCommand({
-			id: 'force-refresh-cache',
-			name: 'Refresh document cache',
+			id: "force-refresh-cache",
+			name: "Refresh document cache",
 			callback: () => {
-				new Notice('Refreshing paperless cache.');
+				new Notice("Refreshing paperless cache.");
 				refreshCacheFromPaperless(this.settings, false);
-			}
+			},
 		});
 
 		this.addSettingTab(new SettingTab(this.app, this));
@@ -58,7 +94,11 @@ export default class ObsidianPaperless extends Plugin {
 	onunload() {}
 
 	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+		this.settings = Object.assign(
+			{},
+			DEFAULT_SETTINGS,
+			await this.loadData()
+		);
 	}
 
 	async saveSettings() {
@@ -70,49 +110,64 @@ let cachedResult: RequestUrlResponse;
 let tagCache = new Map();
 
 async function testConnection(settings: PluginSettings) {
-	new Notice("Testing connection to " + settings.paperlessUrl)
-	const url = new URL(settings.paperlessUrl + '/api/documents/');
+	new Notice("Testing connection to " + settings.paperlessUrl);
+	const url = new URL(settings.paperlessUrl + "/api/documents/");
 	try {
 		const result = await requestUrl({
 			url: url.toString(),
 			headers: {
-				'Authorization': 'token ' + settings.paperlessAuthToken
-			}
-		})
-		if (result.status == 200 && result.json['results']) {
-			new Notice("Connection successful")
+				Authorization: "token " + settings.paperlessAuthToken,
+			},
+		});
+		if (result.status == 200 && result.json["results"]) {
+			new Notice("Connection successful");
 		}
-	} catch(exception) {
-		new Notice("Failed to connect to " + settings.paperlessUrl + " - check the console for additional information.")
-		console.log("Failed connection to " + url + " with error: " + exception)
-	}	
+	} catch (exception) {
+		new Notice(
+			"Failed to connect to " +
+				settings.paperlessUrl +
+				" - check the console for additional information."
+		);
+		console.log(
+			"Failed connection to " + url + " with error: " + exception
+		);
+	}
 }
 
-async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) {
-	const url = new URL(settings.paperlessUrl + '/api/documents/?format=json');
+async function refreshCacheFromPaperless(
+	settings: PluginSettings,
+	silent = true
+) {
+	const url = new URL(settings.paperlessUrl + "/api/documents/?format=json");
 	const result = await requestUrl({
 		url: url.toString(),
 		headers: {
-			'Authorization': 'token ' + settings.paperlessAuthToken
-		}
-	})
+			Authorization: "token " + settings.paperlessAuthToken,
+		},
+	});
 	cachedResult = result;
 
 	// Cache data relating to tags
-	const tagUrl = new URL(settings.paperlessUrl + '/api/tags/?format=json');
+	const tagUrl = new URL(settings.paperlessUrl + "/api/tags/?format=json");
 	const tagResult = await requestUrl({
 		url: tagUrl.toString(),
 		headers: {
-			"accept": "application/json; version=5",
-			'Authorization': 'token ' + settings.paperlessAuthToken
-		}
-	})
-	for (let i = 0; i < tagResult.json['results'].length; i++) {
-		let current = tagResult.json['results'][i];
-		tagCache.set(current['id'], current);
+			accept: "application/json; version=5",
+			Authorization: "token " + settings.paperlessAuthToken,
+		},
+	});
+	for (let i = 0; i < tagResult.json["results"].length; i++) {
+		let current = tagResult.json["results"][i];
+		tagCache.set(current["id"], current);
 	}
-	if(!silent) {
-		new Notice('Paperless cache refresh completed. Found ' + cachedResult.json['all'].length + ' documents and ' + tagCache.size + ' tags.');
+	if (!silent) {
+		new Notice(
+			"Paperless cache refresh completed. Found " +
+				cachedResult.json["all"].length +
+				" documents and " +
+				tagCache.size +
+				" tags."
+		);
 	}
 }
 
@@ -130,7 +185,7 @@ function wordAtCursor(editor: Editor): EditorRange | null {
 		if (cursor.ch >= start && cursor.ch <= end) {
 			return {
 				from: { line: cursor.line, ch: start },
-				to: { line: cursor.line, ch: end }
+				to: { line: cursor.line, ch: end },
 			};
 		}
 	}
@@ -139,20 +194,23 @@ function wordAtCursor(editor: Editor): EditorRange | null {
 }
 
 /// Search the Paperless URL from selection / cursor position
-function searchPaperlessUrl(editor: Editor, settings: PluginSettings): PaperlessInsertionData | null {
+function searchPaperlessUrl(
+	editor: Editor,
+	settings: PluginSettings
+): PaperlessInsertionData | null {
 	const wordRange = wordAtCursor(editor);
 	if (wordRange === null) {
 		return null;
 	}
 
-	const text = editor.getRange(wordRange.from, wordRange.to)
+	const text = editor.getRange(wordRange.from, wordRange.to);
 
 	// find documentId in the selection using a regex
 	const normalizedUrl = new URL(settings.paperlessUrl).toString();
 	const quotedUrl = escapeRegExp(normalizedUrl);
 	const urlVariants = [
 		`${quotedUrl}api/documents/(\\d+)/preview`,
-		`${quotedUrl}documents/(\\d+)/details`
+		`${quotedUrl}documents/(\\d+)/details`,
 	];
 
 	// find a matching URL variant
@@ -162,7 +220,7 @@ function searchPaperlessUrl(editor: Editor, settings: PluginSettings): Paperless
 		if (match) {
 			return {
 				documentId: match[1],
-				range: wordRange
+				range: wordRange,
 			};
 		}
 	}
@@ -171,50 +229,75 @@ function searchPaperlessUrl(editor: Editor, settings: PluginSettings): Paperless
 	return null;
 }
 
-async function getExistingShareLink(settings: PluginSettings, documentId: string) {
-	const url = new URL(settings.paperlessUrl + '/api/documents/' + documentId + '/share_links/?format=json');
+async function getExistingShareLink(
+	settings: PluginSettings,
+	documentId: string
+) {
+	const url = new URL(
+		settings.paperlessUrl +
+			"/api/documents/" +
+			documentId +
+			"/share_links/?format=json"
+	);
 	let result;
 	try {
 		result = await requestUrl({
 			url: url.toString(),
 			headers: {
-				'Authorization': 'token ' + settings.paperlessAuthToken
-			}
-		})
+				Authorization: "token " + settings.paperlessAuthToken,
+			},
+		});
 		if (result.status != 200) {
-			console.error("An exception occurred in getExistingShareLink. Response: " + result);
+			console.error(
+				"An exception occurred in getExistingShareLink. Response: " +
+					result
+			);
 			return null;
 		}
 		for (let item of result.json) {
-			if (item['expiration'] == null)  {
-				return new URL(settings.paperlessUrl + '/share/' + item['slug']);
+			if (item["expiration"] == null) {
+				return new URL(
+					settings.paperlessUrl + "/share/" + item["slug"]
+				);
 			}
 		}
 	} catch (e) {
-		console.error("An exception occurred in getExistingShareLink. Exception: " + e + " and response " + result);
+		console.error(
+			"An exception occurred in getExistingShareLink. Exception: " +
+				e +
+				" and response " +
+				result
+		);
 	}
 
 	return null;
 }
 
 async function createShareLink(settings: PluginSettings, documentId: string) {
-	const url = new URL(settings.paperlessUrl + '/api/share_links/');
+	const url = new URL(settings.paperlessUrl + "/api/share_links/");
 	let result;
 	try {
 		result = await requestUrl({
 			url: url.toString(),
-			method: 'POST',
-			contentType: 'application/json',
+			method: "POST",
+			contentType: "application/json",
 			body: '{"document":' + documentId + ',"file_version":"original"}',
 			headers: {
-				'Authorization': 'token ' + settings.paperlessAuthToken
-			}
-		})
+				Authorization: "token " + settings.paperlessAuthToken,
+			},
+		});
 		if (result.status != 201) {
-			console.error("An exception occurred in createShareLink. Response: " + result);
+			console.error(
+				"An exception occurred in createShareLink. Response: " + result
+			);
 		}
 	} catch (e) {
-		console.error("An exception occurred in createShareLink. Exception: " + e + " and response " + result);
+		console.error(
+			"An exception occurred in createShareLink. Exception: " +
+				e +
+				" and response " +
+				result
+		);
 	}
 }
 
@@ -237,119 +320,383 @@ async function getShareLink(settings: PluginSettings, documentId: string) {
 	return link;
 }
 
+async function saveThumbnail(
+	app: App,
+	settings: PluginSettings,
+	documentId: string,
+	documentTitle: string
+): Promise<string | null> {
+	const folderPath = normalizePath(settings.thumbnailStoragePath);
+	if (folderPath) {
+		const folderRef = app.vault.getAbstractFileByPath(folderPath);
+		const folderExists = !!folderRef && folderRef instanceof TFolder;
+		if (!folderExists) {
+			await app.vault.createFolder(folderPath);
+		}
+	}
+
+	const filename = "paperless-thumb-" + documentId + ".png";
+	const filePath = folderPath ? folderPath + "/" + filename : filename;
+	const fileRef = app.vault.getAbstractFileByPath(filePath);
+	const fileExists = !!fileRef && fileRef instanceof TFile;
+
+	if (!fileExists) {
+		const thumbUrl =
+			settings.paperlessUrl + "/api/documents/" + documentId + "/thumb/";
+		try {
+			const result = await requestUrl({
+				url: thumbUrl.toString(),
+				headers: {
+					Authorization: "token " + settings.paperlessAuthToken,
+				},
+			});
+			await app.vault.createBinary(filePath, result.arrayBuffer);
+		} catch (e) {
+			console.error("Failed to save thumbnail: " + e);
+			return null;
+		}
+	}
+
+	return filePath;
+}
+
+async function createDocumentLink(
+	app: App,
+	editor: Editor,
+	settings: PluginSettings,
+	paperlessUrl: PaperlessInsertionData,
+	documentTitle: string,
+	withThumbnail: boolean = true
+) {
+	const documentUrl =
+		settings.paperlessUrl +
+		"/documents/" +
+		paperlessUrl.documentId +
+		"/details";
+
+	let linkText: string;
+
+	if (withThumbnail) {
+		const thumbnailPath = await saveThumbnail(
+			app,
+			settings,
+			paperlessUrl.documentId,
+			documentTitle
+		);
+
+		if (!thumbnailPath) {
+			new Notice("Failed to save thumbnail");
+			return;
+		}
+
+		linkText =
+			"[![" +
+			documentTitle +
+			"](" +
+			thumbnailPath +
+			")](" +
+			documentUrl +
+			")";
+	} else {
+		linkText = "[" + documentTitle + "](" + documentUrl + ")";
+	}
+
+	editor.replaceRange(
+		linkText,
+		paperlessUrl.range.from,
+		paperlessUrl.range.to
+	);
+}
+
 // Heavily inspired by https://github.com/RyotaUshio/obsidian-pdf-plus/blob/127ea5b94bb8f8fa0d4c66bcd77b3809caa50b21/src/modals/external-pdf-modals.ts#L249
-async function createDocument(editor: Editor, settings: PluginSettings, paperlessUrl: PaperlessInsertionData) {
+async function createDocument(
+	editor: Editor,
+	settings: PluginSettings,
+	paperlessUrl: PaperlessInsertionData
+) {
 	// Create the parent folder
 	const folderPath = normalizePath(settings.documentStoragePath);
 	if (folderPath) {
 		const folderRef = this.app.vault.getAbstractFileByPath(folderPath);
-		const folderExists = !!(folderRef) && folderRef instanceof TFolder;
+		const folderExists = !!folderRef && folderRef instanceof TFolder;
 		if (!folderExists) {
 			await this.app.vault.createFolder(folderPath);
 		}
 	}
-	
-	const filename = 'paperless-' + paperlessUrl.documentId + '.pdf';
-	const fileRef = this.app.vault.getAbstractFileByPath(folderPath + '/' + filename); 
-	const fileExists = !!(fileRef) && fileRef instanceof TFile;
+
+	const filename = "paperless-" + paperlessUrl.documentId + ".pdf";
+	const fileRef = this.app.vault.getAbstractFileByPath(
+		folderPath + "/" + filename
+	);
+	const fileExists = !!fileRef && fileRef instanceof TFile;
 	if (!fileExists) {
 		const shareLink = await getShareLink(settings, paperlessUrl.documentId);
 		if (shareLink) {
-			await this.app.vault.create(folderPath + '/' + filename, shareLink.href);
+			await this.app.vault.create(
+				folderPath + "/" + filename,
+				shareLink.href
+			);
 		}
 	}
 
-	editor.replaceRange('![[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
+	editor.replaceRange(
+		"![[" + filename + "]]",
+		paperlessUrl.range.from,
+		paperlessUrl.range.to
+	);
+}
+
+class LinkTypeSelectionModal extends Modal {
+	app: App;
+	editor: Editor;
+	settings: PluginSettings;
+	documentInfo: PaperlessInsertionData;
+	documentTitle: string;
+	parentModal: DocumentSelectorModal;
+
+	constructor(
+		app: App,
+		editor: Editor,
+		settings: PluginSettings,
+		documentInfo: PaperlessInsertionData,
+		documentTitle: string,
+		parentModal: DocumentSelectorModal
+	) {
+		super(app);
+		this.app = app;
+		this.editor = editor;
+		this.settings = settings;
+		this.documentInfo = documentInfo;
+		this.documentTitle = documentTitle;
+		this.parentModal = parentModal;
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.empty();
+
+		contentEl.createEl("h3", { text: "Choose link type" });
+		contentEl.createEl("p", {
+			text: "How would you like to insert the document?",
+		});
+
+		const buttonContainer = contentEl.createDiv({
+			cls: "modal-button-container",
+		});
+		buttonContainer.setCssStyles({
+			display: "flex",
+			gap: "10px",
+			marginTop: "20px",
+			justifyContent: "center",
+		});
+
+		const thumbnailButton = buttonContainer.createEl("button", {
+			text: "With Thumbnail",
+		});
+		thumbnailButton.setCssStyles({ flex: "1" });
+		thumbnailButton.onclick = async () => {
+			this.close();
+			await createDocumentLink(
+				this.app,
+				this.editor,
+				this.settings,
+				this.documentInfo,
+				this.documentTitle,
+				true
+			);
+			this.parentModal.close();
+		};
+
+		const textLinkButton = buttonContainer.createEl("button", {
+			text: "Text Link Only",
+		});
+		textLinkButton.setCssStyles({ flex: "1" });
+		textLinkButton.onclick = async () => {
+			this.close();
+			await createDocumentLink(
+				this.app,
+				this.editor,
+				this.settings,
+				this.documentInfo,
+				this.documentTitle,
+				false
+			);
+			this.parentModal.close();
+		};
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+	}
 }
 
 class DocumentSelectorModal extends Modal {
 	editor: Editor;
 	settings: PluginSettings;
 	page: number;
+	insertionMode: "embed" | "link";
 
-	constructor(app: App, editor: Editor, settings: PluginSettings) {
+	constructor(
+		app: App,
+		editor: Editor,
+		settings: PluginSettings,
+		insertionMode: "embed" | "link" = "embed"
+	) {
 		super(app);
 		this.editor = editor;
 		this.settings = settings;
 		this.page = 0;
+		this.insertionMode = insertionMode;
 	}
 
 	async displayThumbnail(imgElement: HTMLImageElement, documentId: string) {
-		const thumbUrl = this.settings.paperlessUrl + '/api/documents/' + documentId + '/thumb/';
+		const thumbUrl =
+			this.settings.paperlessUrl +
+			"/api/documents/" +
+			documentId +
+			"/thumb/";
 		const result = await requestUrl({
 			url: thumbUrl.toString(),
 			headers: {
-				'Authorization': 'token ' + this.settings.paperlessAuthToken
-			}
-		})	
+				Authorization: "token " + this.settings.paperlessAuthToken,
+			},
+		});
 		imgElement.src = URL.createObjectURL(new Blob([result.arrayBuffer]));
-	};
+	}
 
 	async displayTags(tagDiv: HTMLDivElement, documentId: string) {
-		const thumbUrl = this.settings.paperlessUrl + '/api/documents/' + documentId + '/';
+		const thumbUrl =
+			this.settings.paperlessUrl + "/api/documents/" + documentId + "/";
 		const result = await requestUrl({
 			url: thumbUrl.toString(),
 			headers: {
-				'Authorization': 'token ' + this.settings.paperlessAuthToken
-			}
-		})
-		const tags = result.json['tags']
+				Authorization: "token " + this.settings.paperlessAuthToken,
+			},
+		});
+		const tags = result.json["tags"];
 		for (let x = 0; x < tags.length; x++) {
 			const currentTag = tagDiv.createDiv();
-			const tagData = tagCache.get(tags[x]);					
-			const tagStr = currentTag.createEl('span', {text: tagData['name']});
-			tagStr.setCssStyles({color: tagData['text_color'], fontSize: '0.7em'});
-			currentTag.setCssStyles({background: tagData['color'], borderRadius: '8px', padding: '2px', marginTop: '1px', marginRight: '5px'})
+			const tagData = tagCache.get(tags[x]);
+			const tagStr = currentTag.createEl("span", {
+				text: tagData["name"],
+			});
+			tagStr.setCssStyles({
+				color: tagData["text_color"],
+				fontSize: "0.7em",
+			});
+			currentTag.setCssStyles({
+				background: tagData["color"],
+				borderRadius: "8px",
+				padding: "2px",
+				marginTop: "1px",
+				marginRight: "5px",
+			});
 		}
-	};
+	}
+
+	async getDocumentTitle(documentId: string): Promise<string> {
+		const docUrl =
+			this.settings.paperlessUrl + "/api/documents/" + documentId + "/";
+		const result = await requestUrl({
+			url: docUrl.toString(),
+			headers: {
+				Authorization: "token " + this.settings.paperlessAuthToken,
+			},
+		});
+		return result.json["title"] || "Paperless Document " + documentId;
+	}
 
 	async onOpen() {
-		const {contentEl} = this;
+		const { contentEl } = this;
 		if (cachedResult == null) {
 			await refreshCacheFromPaperless(this.settings);
 		}
 
-		const documentDiv = contentEl.createDiv({cls: 'obsidian-paperless-row'});
-		const left = documentDiv.createDiv({cls: 'obsidian-paperless-column'});
-		const right = documentDiv.createDiv({cls: 'obsidian-paperless-column'});
+		const documentDiv = contentEl.createDiv({
+			cls: "obsidian-paperless-row",
+		});
+		const left = documentDiv.createDiv({
+			cls: "obsidian-paperless-column",
+		});
+		const right = documentDiv.createDiv({
+			cls: "obsidian-paperless-column",
+		});
 		const bottomDiv = contentEl.createDiv();
-		const availableDocumentIds = cachedResult.json['all'].sort((a:String, b:String) => {return +a - +b}).reverse();
-		let observer = new IntersectionObserver(() => {
-			const startIndex = this.page;
-			let endIndex = this.page + 16;
-			if (endIndex > availableDocumentIds.length) {
-				endIndex = availableDocumentIds.length;
-			}
-			this.page = endIndex;
-			for (let i = startIndex; i < endIndex; i++) {
-				const documentId = availableDocumentIds[i];
-				const overallDiv = ( i & 1 ) ? right.createDiv({cls: 'obsidian-paperless-overallDiv'}) : left.createDiv({cls: 'obsidian-paperless-overallDiv'});
-				const imageDiv = overallDiv.createDiv({cls: 'obsidian-paperless-imageDiv'});
-				const tagDiv = overallDiv.createDiv({cls: 'obsidian-paperless-tagDiv'});
-				this.displayTags(tagDiv, documentId);
-				const imgElement = imageDiv.createEl('img');
-				imgElement.width = 260;
-				imgElement.onclick = () => {
-					const cursor = this.editor.getCursor();
-					const line = this.editor.getLine(cursor.line);				
-					const documentInfo: PaperlessInsertionData = {
-						documentId: documentId,
-						range: { 
-							from: { line: cursor.line, ch: cursor.ch },
-							to: { line: cursor.line, ch: cursor.ch }
-						}
-					}
-					createDocument(this.editor, this.settings, documentInfo);
-					overallDiv.setCssStyles({opacity: '0.5'})
+		const availableDocumentIds = cachedResult.json["all"]
+			.sort((a: String, b: String) => {
+				return +a - +b;
+			})
+			.reverse();
+		let observer = new IntersectionObserver(
+			() => {
+				const startIndex = this.page;
+				let endIndex = this.page + 16;
+				if (endIndex > availableDocumentIds.length) {
+					endIndex = availableDocumentIds.length;
 				}
-				this.displayThumbnail(imgElement, documentId);
-			}
-		}, {threshold: [0.1]});
+				this.page = endIndex;
+				for (let i = startIndex; i < endIndex; i++) {
+					const documentId = availableDocumentIds[i];
+					const overallDiv =
+						i & 1
+							? right.createDiv({
+									cls: "obsidian-paperless-overallDiv",
+							  })
+							: left.createDiv({
+									cls: "obsidian-paperless-overallDiv",
+							  });
+					const imageDiv = overallDiv.createDiv({
+						cls: "obsidian-paperless-imageDiv",
+					});
+					const tagDiv = overallDiv.createDiv({
+						cls: "obsidian-paperless-tagDiv",
+					});
+					this.displayTags(tagDiv, documentId);
+					const imgElement = imageDiv.createEl("img");
+					imgElement.width = 260;
+					imgElement.onclick = async () => {
+						const cursor = this.editor.getCursor();
+						const line = this.editor.getLine(cursor.line);
+						const documentInfo: PaperlessInsertionData = {
+							documentId: documentId,
+							range: {
+								from: { line: cursor.line, ch: cursor.ch },
+								to: { line: cursor.line, ch: cursor.ch },
+							},
+						};
+
+						if (this.insertionMode === "link") {
+							const title = await this.getDocumentTitle(
+								documentId
+							);
+							new LinkTypeSelectionModal(
+								this.app,
+								this.editor,
+								this.settings,
+								documentInfo,
+								title,
+								this
+							).open();
+						} else {
+							createDocument(
+								this.editor,
+								this.settings,
+								documentInfo
+							);
+						}
+						overallDiv.setCssStyles({ opacity: "0.5" });
+					};
+					this.displayThumbnail(imgElement, documentId);
+				}
+			},
+			{ threshold: [0.1] }
+		);
 		observer.observe(bottomDiv);
 	}
 
 	onClose() {
-		const {contentEl} = this;
+		const { contentEl } = this;
 		contentEl.empty();
 	}
 }
@@ -363,45 +710,66 @@ class SettingTab extends PluginSettingTab {
 	}
 
 	display(): void {
-		const {containerEl} = this;
+		const { containerEl } = this;
 		containerEl.empty();
 
 		new Setting(containerEl)
-		.setName('Paperless URL')
-		.setDesc('Full URL to your paperless instance.')
-		.addText(text => text
-			.setValue(this.plugin.settings.paperlessUrl)
-			.onChange(async (value) => {
-				this.plugin.settings.paperlessUrl = value;
-				await this.plugin.saveSettings();
-			}));
+			.setName("Paperless URL")
+			.setDesc("Full URL to your paperless instance.")
+			.addText((text) =>
+				text
+					.setValue(this.plugin.settings.paperlessUrl)
+					.onChange(async (value) => {
+						this.plugin.settings.paperlessUrl = value;
+						await this.plugin.saveSettings();
+					})
+			);
 		new Setting(containerEl)
-			.setName('Paperless authentication token')
-			.setDesc('Token obtained using https://docs.paperless-ngx.com/api/#authorization')
-			.addText(text => text
-				.setValue(this.plugin.settings.paperlessAuthToken)
-				.onChange(async (value) => {
-					this.plugin.settings.paperlessAuthToken = value;
-					await this.plugin.saveSettings();
-				})
-				.inputEl.type = 'password');
+			.setName("Paperless authentication token")
+			.setDesc(
+				"Token obtained using https://docs.paperless-ngx.com/api/#authorization"
+			)
+			.addText(
+				(text) =>
+					(text
+						.setValue(this.plugin.settings.paperlessAuthToken)
+						.onChange(async (value) => {
+							this.plugin.settings.paperlessAuthToken = value;
+							await this.plugin.saveSettings();
+						}).inputEl.type = "password")
+			);
 		new Setting(containerEl)
-			.setName('Document storage path')
-			.setDesc('Location for stored documents.')
-			.addText(text => text
-				.setValue(this.plugin.settings.documentStoragePath)
-				.onChange(async (value) => {
-					this.plugin.settings.documentStoragePath = value;
-					await this.plugin.saveSettings();
-				}));
+			.setName("Document storage path")
+			.setDesc("Location for stored documents.")
+			.addText((text) =>
+				text
+					.setValue(this.plugin.settings.documentStoragePath)
+					.onChange(async (value) => {
+						this.plugin.settings.documentStoragePath = value;
+						await this.plugin.saveSettings();
+					})
+			);
 		new Setting(containerEl)
-			.setName('Test connection')
-			.setDesc('Validate the connection between obsidian and your paperless instance.')
+			.setName("Thumbnail storage path")
+			.setDesc("Location for stored document thumbnails.")
+			.addText((text) =>
+				text
+					.setValue(this.plugin.settings.thumbnailStoragePath)
+					.onChange(async (value) => {
+						this.plugin.settings.thumbnailStoragePath = value;
+						await this.plugin.saveSettings();
+					})
+			);
+		new Setting(containerEl)
+			.setName("Test connection")
+			.setDesc(
+				"Validate the connection between obsidian and your paperless instance."
+			)
 			.addButton(async (button) => {
-				button.setButtonText("Test connection")
-				button.onClick(async() => {
-					testConnection(this.plugin.settings)
-				})
-			})
+				button.setButtonText("Test connection");
+				button.onClick(async () => {
+					testConnection(this.plugin.settings);
+				});
+			});
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,1452 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+    devDependencies:
+      '@types/lodash':
+        specifier: ^4.17.16
+        version: 4.17.20
+      '@types/node':
+        specifier: ^16.11.6
+        version: 16.18.126
+      '@typescript-eslint/eslint-plugin':
+        specifier: 5.29.0
+        version: 5.29.0(@typescript-eslint/parser@5.29.0(eslint@8.57.1)(typescript@4.7.4))(eslint@8.57.1)(typescript@4.7.4)
+      '@typescript-eslint/parser':
+        specifier: 5.29.0
+        version: 5.29.0(eslint@8.57.1)(typescript@4.7.4)
+      builtin-modules:
+        specifier: 3.3.0
+        version: 3.3.0
+      esbuild:
+        specifier: 0.17.3
+        version: 0.17.3
+      obsidian:
+        specifier: latest
+        version: 1.10.0(@codemirror/state@6.5.0)(@codemirror/view@6.38.1)
+      tslib:
+        specifier: 2.4.0
+        version: 2.4.0
+      typescript:
+        specifier: 4.7.4
+        version: 4.7.4
+
+packages:
+
+  '@codemirror/state@6.5.0':
+    resolution: {integrity: sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==}
+
+  '@codemirror/view@6.38.1':
+    resolution: {integrity: sha512-RmTOkE7hRU3OVREqFVITWHz6ocgBjv08GoePscAakgVQfciA3SGCEk7mb9IzwW61cKKmlTpHXG6DUE5Ubx+MGQ==}
+
+  '@esbuild/android-arm64@0.17.3':
+    resolution: {integrity: sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.17.3':
+    resolution: {integrity: sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.17.3':
+    resolution: {integrity: sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.17.3':
+    resolution: {integrity: sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.17.3':
+    resolution: {integrity: sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.17.3':
+    resolution: {integrity: sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.17.3':
+    resolution: {integrity: sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.17.3':
+    resolution: {integrity: sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.17.3':
+    resolution: {integrity: sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.17.3':
+    resolution: {integrity: sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.17.3':
+    resolution: {integrity: sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.17.3':
+    resolution: {integrity: sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.17.3':
+    resolution: {integrity: sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.17.3':
+    resolution: {integrity: sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.17.3':
+    resolution: {integrity: sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.17.3':
+    resolution: {integrity: sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.17.3':
+    resolution: {integrity: sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.17.3':
+    resolution: {integrity: sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.17.3':
+    resolution: {integrity: sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.17.3':
+    resolution: {integrity: sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.17.3':
+    resolution: {integrity: sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.17.3':
+    resolution: {integrity: sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.1':
+    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/eslintrc@2.1.4':
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@8.57.1':
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@humanwhocodes/config-array@0.13.0':
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@2.0.3':
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@types/codemirror@5.60.8':
+    resolution: {integrity: sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lodash@4.17.20':
+    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
+
+  '@types/node@16.18.126':
+    resolution: {integrity: sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==}
+
+  '@types/tern@0.23.9':
+    resolution: {integrity: sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==}
+
+  '@typescript-eslint/eslint-plugin@5.29.0':
+    resolution: {integrity: sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^5.0.0
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/parser@5.29.0':
+    resolution: {integrity: sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/scope-manager@5.29.0':
+    resolution: {integrity: sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript-eslint/type-utils@5.29.0':
+    resolution: {integrity: sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/types@5.29.0':
+    resolution: {integrity: sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@typescript-eslint/typescript-estree@5.29.0':
+    resolution: {integrity: sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/utils@5.29.0':
+    resolution: {integrity: sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@typescript-eslint/visitor-keys@5.29.0':
+    resolution: {integrity: sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  builtin-modules@3.3.0:
+    resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
+    engines: {node: '>=6'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
+  esbuild@0.17.3:
+    resolution: {integrity: sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@5.1.1:
+    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
+    engines: {node: '>=8.0.0'}
+
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-utils@3.0.0:
+    resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
+    engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
+    peerDependencies:
+      eslint: '>=5'
+
+  eslint-visitor-keys@2.1.0:
+    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
+    engines: {node: '>=10'}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@4.3.0:
+    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.19.1:
+    resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
+  flatted@3.3.3:
+    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  functional-red-black-tree@1.0.1:
+    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  moment@2.29.4:
+    resolution: {integrity: sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  obsidian@1.10.0:
+    resolution: {integrity: sha512-F7hhnmGRQD1TanDPFT//LD3iKNUVd7N8sKL7flCCHRszfTxpDJ39j3T7LHbcGpyid906i6lD5oO+cnfLBzJMKw==}
+    peerDependencies:
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.1
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  regexpp@3.2.0:
+    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
+    engines: {node: '>=8'}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  style-mod@4.1.2:
+    resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.4.0:
+    resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
+
+  tsutils@3.21.0:
+    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
+
+  typescript@4.7.4:
+    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@codemirror/state@6.5.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.38.1':
+    dependencies:
+      '@codemirror/state': 6.5.0
+      crelt: 1.0.6
+      style-mod: 4.1.2
+      w3c-keyname: 2.2.8
+
+  '@esbuild/android-arm64@0.17.3':
+    optional: true
+
+  '@esbuild/android-arm@0.17.3':
+    optional: true
+
+  '@esbuild/android-x64@0.17.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.17.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.17.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.17.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.17.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.17.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.17.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.17.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.17.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.17.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.17.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.17.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.17.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.17.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.17.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.17.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.17.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.17.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.17.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.17.3':
+    optional: true
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint/eslintrc@2.1.4':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.3
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@8.57.1': {}
+
+  '@humanwhocodes/config-array@0.13.0':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.4.3
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@marijn/find-cluster-break@1.0.2': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.19.1
+
+  '@types/codemirror@5.60.8':
+    dependencies:
+      '@types/tern': 0.23.9
+
+  '@types/estree@1.0.8': {}
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/lodash@4.17.20': {}
+
+  '@types/node@16.18.126': {}
+
+  '@types/tern@0.23.9':
+    dependencies:
+      '@types/estree': 1.0.8
+
+  '@typescript-eslint/eslint-plugin@5.29.0(@typescript-eslint/parser@5.29.0(eslint@8.57.1)(typescript@4.7.4))(eslint@8.57.1)(typescript@4.7.4)':
+    dependencies:
+      '@typescript-eslint/parser': 5.29.0(eslint@8.57.1)(typescript@4.7.4)
+      '@typescript-eslint/scope-manager': 5.29.0
+      '@typescript-eslint/type-utils': 5.29.0(eslint@8.57.1)(typescript@4.7.4)
+      '@typescript-eslint/utils': 5.29.0(eslint@8.57.1)(typescript@4.7.4)
+      debug: 4.4.3
+      eslint: 8.57.1
+      functional-red-black-tree: 1.0.1
+      ignore: 5.3.2
+      regexpp: 3.2.0
+      semver: 7.7.2
+      tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
+      typescript: 4.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@5.29.0(eslint@8.57.1)(typescript@4.7.4)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 5.29.0
+      '@typescript-eslint/types': 5.29.0
+      '@typescript-eslint/typescript-estree': 5.29.0(typescript@4.7.4)
+      debug: 4.4.3
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: 4.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@5.29.0':
+    dependencies:
+      '@typescript-eslint/types': 5.29.0
+      '@typescript-eslint/visitor-keys': 5.29.0
+
+  '@typescript-eslint/type-utils@5.29.0(eslint@8.57.1)(typescript@4.7.4)':
+    dependencies:
+      '@typescript-eslint/utils': 5.29.0(eslint@8.57.1)(typescript@4.7.4)
+      debug: 4.4.3
+      eslint: 8.57.1
+      tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
+      typescript: 4.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@5.29.0': {}
+
+  '@typescript-eslint/typescript-estree@5.29.0(typescript@4.7.4)':
+    dependencies:
+      '@typescript-eslint/types': 5.29.0
+      '@typescript-eslint/visitor-keys': 5.29.0
+      debug: 4.4.3
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.7.2
+      tsutils: 3.21.0(typescript@4.7.4)
+    optionalDependencies:
+      typescript: 4.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@5.29.0(eslint@8.57.1)(typescript@4.7.4)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      '@typescript-eslint/scope-manager': 5.29.0
+      '@typescript-eslint/types': 5.29.0
+      '@typescript-eslint/typescript-estree': 5.29.0(typescript@4.7.4)
+      eslint: 8.57.1
+      eslint-scope: 5.1.1
+      eslint-utils: 3.0.0(eslint@8.57.1)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/visitor-keys@5.29.0':
+    dependencies:
+      '@typescript-eslint/types': 5.29.0
+      eslint-visitor-keys: 3.4.3
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  array-union@2.1.0: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  builtin-modules@3.3.0: {}
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  crelt@1.0.6: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
+  esbuild@0.17.3:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.17.3
+      '@esbuild/android-arm64': 0.17.3
+      '@esbuild/android-x64': 0.17.3
+      '@esbuild/darwin-arm64': 0.17.3
+      '@esbuild/darwin-x64': 0.17.3
+      '@esbuild/freebsd-arm64': 0.17.3
+      '@esbuild/freebsd-x64': 0.17.3
+      '@esbuild/linux-arm': 0.17.3
+      '@esbuild/linux-arm64': 0.17.3
+      '@esbuild/linux-ia32': 0.17.3
+      '@esbuild/linux-loong64': 0.17.3
+      '@esbuild/linux-mips64el': 0.17.3
+      '@esbuild/linux-ppc64': 0.17.3
+      '@esbuild/linux-riscv64': 0.17.3
+      '@esbuild/linux-s390x': 0.17.3
+      '@esbuild/linux-x64': 0.17.3
+      '@esbuild/netbsd-x64': 0.17.3
+      '@esbuild/openbsd-x64': 0.17.3
+      '@esbuild/sunos-x64': 0.17.3
+      '@esbuild/win32-arm64': 0.17.3
+      '@esbuild/win32-ia32': 0.17.3
+      '@esbuild/win32-x64': 0.17.3
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@5.1.1:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 4.3.0
+
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-utils@3.0.0(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 2.1.0
+
+  eslint-visitor-keys@2.1.0: {}
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint@8.57.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.3.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.0
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 3.4.3
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@4.3.0: {}
+
+  estraverse@5.3.0: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  file-entry-cache@6.0.1:
+    dependencies:
+      flat-cache: 3.2.0
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@3.2.0:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+      rimraf: 3.0.2
+
+  flatted@3.3.3: {}
+
+  fs.realpath@1.0.0: {}
+
+  functional-red-black-tree@1.0.1: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
+  graphemer@1.4.0: {}
+
+  has-flag@4.0.0: {}
+
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-path-inside@3.0.3: {}
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.1
+
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  moment@2.29.4: {}
+
+  ms@2.1.3: {}
+
+  natural-compare@1.4.0: {}
+
+  obsidian@1.10.0(@codemirror/state@6.5.0)(@codemirror/view@6.38.1):
+    dependencies:
+      '@codemirror/state': 6.5.0
+      '@codemirror/view': 6.38.1
+      '@types/codemirror': 5.60.8
+      moment: 2.29.4
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-type@4.0.0: {}
+
+  picomatch@2.3.1: {}
+
+  prelude-ls@1.2.1: {}
+
+  punycode@2.3.1: {}
+
+  queue-microtask@1.2.3: {}
+
+  regexpp@3.2.0: {}
+
+  resolve-from@4.0.0: {}
+
+  reusify@1.1.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  semver@7.7.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  slash@3.0.0: {}
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-json-comments@3.1.1: {}
+
+  style-mod@4.1.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  text-table@0.2.0: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tslib@1.14.1: {}
+
+  tslib@2.4.0: {}
+
+  tsutils@3.21.0(typescript@4.7.4):
+    dependencies:
+      tslib: 1.14.1
+      typescript: 4.7.4
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
+  type-fest@0.20.2: {}
+
+  typescript@4.7.4: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  w3c-keyname@2.2.8: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
+
+  yocto-queue@0.1.0: {}


### PR DESCRIPTION
## Add document link insertion with thumbnail preview

Hey, I've added a option to insert links to the paperless pdf's, not only including them.

### Summary
This PR adds a new command to insert links to Paperless documents with optional thumbnail previews, providing an alternative to embedding full PDFs.

### New Features

#### 1. Insert Document Link Command
- New command: `Paperless: Insert document link`
- Allows users to reference documents without embedding the full PDF

#### 2. Link Type Selection Modal
After selecting a document, users can choose between:
- **With Thumbnail**: Creates a clickable link with a locally stored thumbnail image as preview
- **Text Link Only**: Creates a simple Markdown link without any preview image

### Benefits
- Reduces vault size by not embedding full PDFs
- Maintains visual document references with thumbnails
- Provides flexibility between thumbnail and text-only links
- Links directly to document details page in Paperless

### Backward Compatibility
All existing functionality remains unchanged. The original `Insert document` command continues to work as before, embedding PDFs using share links.