### PR TITLE
QOL features

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -167,6 +167,15 @@ function searchPaperlessUrl(editor: Editor, settings: PluginSettings): Paperless
 		}
 	}
 
+	// also match [[paperless-{id}.pdf]] wiki links
+	const wikiLinkMatch = text.match(/\[\[paperless-(\d+)\.pdf\]\]/);
+	if (wikiLinkMatch) {
+		return {
+			documentId: wikiLinkMatch[1],
+			range: wordRange
+		};
+	}
+
 	// nothing found
 	return null;
 }

--- a/main.ts
+++ b/main.ts
@@ -641,7 +641,7 @@ class DocumentSelectorModal extends Modal {
 			imgElement.width = (totalWidth / 2) - 5;
 			imgElement.style.cursor = 'pointer';
 
-			imgElement.onclick = () => {
+			imgElement.onclick = async () => {
 				const cursor = this.editor.getCursor();
 				const documentInfo: PaperlessInsertionData = {
 					documentId: documentId,
@@ -650,8 +650,8 @@ class DocumentSelectorModal extends Modal {
 						to: { line: cursor.line, ch: cursor.ch }
 					}
 				}
-				createDocument(this.app, this.editor, this.settings, documentInfo);
-				overallDiv.setCssStyles({opacity: '0.5'});
+				await createDocument(this.app, this.editor, this.settings, documentInfo);
+				this.close();
 			};
 
 			imgElement.onerror = () => {

--- a/main.ts
+++ b/main.ts
@@ -216,7 +216,9 @@ async function getExistingShareLink(settings: PluginSettings, documentId: string
 	return null;
 }
 
-async function createShareLink(settings: PluginSettings, documentId: string) {
+type ShareLinkFileVersion = 'archive' | 'original';
+
+async function createShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion) {
 	const url = new URL(settings.paperlessUrl + '/api/share_links/');
 	let result;
 	try {
@@ -224,36 +226,41 @@ async function createShareLink(settings: PluginSettings, documentId: string) {
 			url: url.toString(),
 			method: 'POST',
 			contentType: 'application/json',
-			body: '{"document":' + documentId + ',"file_version":"original"}',
+			body: JSON.stringify({ document: documentId, file_version: fileVersion }),
 			headers: {
 				'Authorization': 'token ' + settings.paperlessAuthToken
 			}
 		})
-		if (result.status != 201) {
-			console.error("An exception occurred in createShareLink. Response: " + result);
-		}
+		return result.status === 201;
 	} catch (e) {
 		console.error("An exception occurred in createShareLink. Exception: " + e + " and response " + result);
+		return false;
 	}
 }
 
-async function getShareLink(settings: PluginSettings, documentId: string) {
-	let link = await getExistingShareLink(settings, documentId);
-	if (!link) {
-		createShareLink(settings, documentId);
-		link = await getExistingShareLink(settings, documentId);
-		if (link == null) {
-			// Sometimes this takes a while, give it five immediate retries before giving up.
-			for (let i = 0; i < 5; i++) {
-				link = await getExistingShareLink(settings, documentId);
-				if (link) {
-					break;
-				}
-			}
+async function findShareLink(settings: PluginSettings, documentId: string, attempts = 1) {
+	for (let i = 0; i < attempts; i++) {
+		const link = await getExistingShareLink(settings, documentId);
+		if (link) {
+			return link;
 		}
 	}
 
-	return link;
+	return null;
+}
+
+async function createAndFindShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion) {
+	if (await createShareLink(settings, documentId, fileVersion)) {
+		return await findShareLink(settings, documentId, 6);
+	}
+
+	return null;
+}
+
+async function getShareLink(settings: PluginSettings, documentId: string) {
+	return await findShareLink(settings, documentId)
+		?? await createAndFindShareLink(settings, documentId, 'archive')
+		?? await createAndFindShareLink(settings, documentId, 'original');
 }
 
 // Heavily inspired by https://github.com/RyotaUshio/obsidian-pdf-plus/blob/127ea5b94bb8f8fa0d4c66bcd77b3809caa50b21/src/modals/external-pdf-modals.ts#L249

--- a/main.ts
+++ b/main.ts
@@ -38,7 +38,7 @@ export default class ObsidianPaperless extends Plugin {
 			editorCallback: (editor: Editor) => {
 				const paperlessUrl = searchPaperlessUrl(editor, this.settings);
 				if (paperlessUrl) {
-					createDocument(editor, this.settings, paperlessUrl);
+					createDocument(this.app, editor, this.settings, paperlessUrl);
 				}
 			}
 		});
@@ -85,7 +85,7 @@ async function testConnection(settings: PluginSettings) {
 	} catch(exception) {
 		new Notice("Failed to connect to " + settings.paperlessUrl + " - check the console for additional information.")
 		console.log("Failed connection to " + url + " with error: " + exception)
-	}	
+	}
 }
 
 async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) {
@@ -112,7 +112,7 @@ async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) 
 		tagCache.set(current['id'], current);
 	}
 	if(!silent) {
-		new Notice('Paperless cache refresh completed. Found ' + cachedResult.json['all'].length + ' documents and ' + tagCache.size + ' tags.');
+		new Notice('Paperless cache refresh completed. Found ' + cachedResult.json['results'].length + ' documents and ' + tagCache.size + ' tags.');
 	}
 }
 
@@ -238,24 +238,28 @@ async function getShareLink(settings: PluginSettings, documentId: string) {
 }
 
 // Heavily inspired by https://github.com/RyotaUshio/obsidian-pdf-plus/blob/127ea5b94bb8f8fa0d4c66bcd77b3809caa50b21/src/modals/external-pdf-modals.ts#L249
-async function createDocument(editor: Editor, settings: PluginSettings, paperlessUrl: PaperlessInsertionData) {
+async function createDocument(app: App, editor: Editor, settings: PluginSettings, paperlessUrl: PaperlessInsertionData) {
 	// Create the parent folder
 	const folderPath = normalizePath(settings.documentStoragePath);
 	if (folderPath) {
-		const folderRef = this.app.vault.getAbstractFileByPath(folderPath);
+		const folderRef = app.vault.getAbstractFileByPath(folderPath);
 		const folderExists = !!(folderRef) && folderRef instanceof TFolder;
 		if (!folderExists) {
-			await this.app.vault.createFolder(folderPath);
+			await app.vault.createFolder(folderPath);
 		}
 	}
-	
+
 	const filename = 'paperless-' + paperlessUrl.documentId + '.pdf';
-	const fileRef = this.app.vault.getAbstractFileByPath(folderPath + '/' + filename); 
+	const fileRef = app.vault.getAbstractFileByPath(folderPath + '/' + filename);
 	const fileExists = !!(fileRef) && fileRef instanceof TFile;
 	if (!fileExists) {
 		const shareLink = await getShareLink(settings, paperlessUrl.documentId);
 		if (shareLink) {
-			await this.app.vault.create(folderPath + '/' + filename, shareLink.href);
+			const response = await requestUrl({
+				url: shareLink.href,
+				method: 'GET'
+			});
+			await app.vault.createBinary(folderPath + '/' + filename, response.arrayBuffer);
 		}
 	}
 
@@ -279,8 +283,8 @@ async function searchPaperlessDocuments(settings: PluginSettings, searchQuery: s
 				'Authorization': 'token ' + settings.paperlessAuthToken
 			}
 		});
-		if (result.status === 200 && result.json['all']) {
-			return result.json['all'];
+		if (result.status === 200 && result.json['results']) {
+			return result.json['results'].map((d: Record<string, any>) => d.id.toString());
 		}
 		console.error('Search returned unexpected response:', result);
 		return [];
@@ -325,7 +329,7 @@ class DocumentSelectorModal extends Modal {
 			headers: {
 				'Authorization': 'token ' + this.settings.paperlessAuthToken
 			}
-		})	
+		})
 		imgElement.src = URL.createObjectURL(new Blob([result.arrayBuffer]));
 	};
 
@@ -340,7 +344,7 @@ class DocumentSelectorModal extends Modal {
 		const tags = result.json['tags']
 		for (let x = 0; x < tags.length; x++) {
 			const currentTag = tagDiv.createDiv();
-			const tagData = tagCache.get(tags[x]);					
+			const tagData = tagCache.get(tags[x]);
 			const tagStr = currentTag.createEl('span', {text: tagData['name']});
 			tagStr.setCssStyles({color: tagData['text_color'], fontSize: '0.7em'});
 			currentTag.setCssStyles({background: tagData['color'], borderRadius: '8px', padding: '2px', marginTop: '1px', marginRight: '5px'})
@@ -446,7 +450,7 @@ class DocumentSelectorModal extends Modal {
 		};
 
 		const totalWidth = contentEl.innerWidth;
-		this.availableDocumentIds = cachedResult.json['all'].sort((a:String, b:String) => {return +a - +b}).reverse();
+		this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:String, b:String) => {return +a - +b}).reverse();
 		const totalAssets = this.availableDocumentIds.length;
 
 		// Create scroll container
@@ -474,16 +478,16 @@ class DocumentSelectorModal extends Modal {
 			// Debounce: wait 500ms after user stops typing
 			this.searchTimeout = window.setTimeout(async () => {
 				const searchQuery = (e.target as HTMLInputElement).value.trim();
-				
+
 			if (searchQuery === '' && this.selectedTags.size === 0) {
 				// Reset to cached results
-				this.availableDocumentIds = cachedResult.json['all'].sort((a:String, b:String) => {return +a - +b}).reverse();
+				this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:String, b:String) => {return +a - +b}).reverse();
 			} else {
 				// Perform search
 				searchInput.disabled = true;
 				loadingDiv.setText('Searching...');
 				loadingDiv.style.display = 'block';
-				
+
 				try {
 					const tagIds = Array.from(this.selectedTags);
 					const searchResults = await searchPaperlessDocuments(this.settings, searchQuery, tagIds);
@@ -501,12 +505,12 @@ class DocumentSelectorModal extends Modal {
 				this.loadedAssets.clear();
 				left.empty();
 				right.empty();
-				
+
 				// Scroll to top
 				if (this.scrollContainer) {
 					this.scrollContainer.scrollTop = 0;
 				}
-				
+
 			// Initial load: load more items to ensure scrollbar appears on large screens
 			const initialBatchSize = Math.max(this.batchSize * 3, 20);
 			this.loadBatch(left, right, totalWidth, this.availableDocumentIds, 0, Math.min(initialBatchSize, this.availableDocumentIds.length), loadingDiv);
@@ -566,30 +570,30 @@ class DocumentSelectorModal extends Modal {
 			const overallDiv = targetColumn.createDiv({cls: 'obsidian-paperless-overallDiv'});
 			const imageDiv = overallDiv.createDiv({cls: 'obsidian-paperless-imageDiv'});
 			const tagDiv = overallDiv.createDiv({cls: 'obsidian-paperless-tagDiv'});
-			
+
 			this.displayTags(tagDiv, documentId);
-			
+
 			const imgElement = imageDiv.createEl('img');
 			imgElement.width = (totalWidth / 2) - 5;
 			imgElement.style.cursor = 'pointer';
-			
+
 			imgElement.onclick = () => {
 				const cursor = this.editor.getCursor();
 				const documentInfo: PaperlessInsertionData = {
 					documentId: documentId,
-					range: { 
+					range: {
 						from: { line: cursor.line, ch: cursor.ch },
 						to: { line: cursor.line, ch: cursor.ch }
 					}
 				}
-				createDocument(this.editor, this.settings, documentInfo);
+				createDocument(this.app, this.editor, this.settings, documentInfo);
 				overallDiv.setCssStyles({opacity: '0.5'});
 			};
-			
+
 			imgElement.onerror = () => {
 				overallDiv.setText('Failed to load');
 			};
-			
+
 			this.displayThumbnail(imgElement, documentId);
 			this.loadedAssets.set(i, overallDiv);
 		}

--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ interface PluginSettings {
 	paperlessUrl: string;
 	paperlessAuthToken: string;
 	documentStoragePath: string;
+	embedDocuments: boolean;
 }
 
 interface PaperlessInsertionData {
@@ -15,7 +16,8 @@ interface PaperlessInsertionData {
 const DEFAULT_SETTINGS: PluginSettings = {
 	paperlessUrl: '',
 	paperlessAuthToken: '',
-	documentStoragePath: ''
+	documentStoragePath: '',
+	embedDocuments: true
 }
 
 export default class ObsidianPaperless extends Plugin {
@@ -280,7 +282,8 @@ async function createDocument(app: App, editor: Editor, settings: PluginSettings
 		}
 	}
 
-	editor.replaceRange('![[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
+	const linkPrefix = settings.embedDocuments ? '![' : '[';
+	editor.replaceRange(linkPrefix + '[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
 }
 
 async function importMissingDocuments(app: App, editor: Editor, settings: PluginSettings) {
@@ -720,6 +723,15 @@ class SettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.documentStoragePath)
 				.onChange(async (value) => {
 					this.plugin.settings.documentStoragePath = value;
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName('Embed documents')
+			.setDesc('When enabled, new documents are inserted as embedded PDFs (![[...]]). Otherwise as links ([[...]]).')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.embedDocuments)
+				.onChange(async (value) => {
+					this.plugin.settings.embedDocuments = value;
 					await this.plugin.saveSettings();
 				}));
 		new Setting(containerEl)

--- a/main.ts
+++ b/main.ts
@@ -52,6 +52,14 @@ export default class ObsidianPaperless extends Plugin {
 			}
 		});
 
+		this.addCommand({
+			id: 'import-missing-paperless',
+			name: 'Import missing documents',
+			editorCallback: async (editor: Editor) => {
+				await importMissingDocuments(this.app, editor, this.settings);
+			}
+		});
+
 		this.addSettingTab(new SettingTab(this.app, this));
 	}
 
@@ -273,6 +281,50 @@ async function createDocument(app: App, editor: Editor, settings: PluginSettings
 	}
 
 	editor.replaceRange('![[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
+}
+
+async function importMissingDocuments(app: App, editor: Editor, settings: PluginSettings) {
+	const content = editor.getValue();
+	const pattern = /!?\[\[paperless-(\d+)\.pdf\]\]/g;
+	const documentIds = new Set<string>();
+	let match;
+	while ((match = pattern.exec(content)) !== null) {
+		documentIds.add(match[1]);
+	}
+
+	if (documentIds.size === 0) {
+		new Notice('No paperless document links found in this note.');
+		return;
+	}
+
+	const folderPath = normalizePath(settings.documentStoragePath);
+	if (folderPath) {
+		const folderRef = app.vault.getAbstractFileByPath(folderPath);
+		const folderExists = !!(folderRef) && folderRef instanceof TFolder;
+		if (!folderExists) {
+			await app.vault.createFolder(folderPath);
+		}
+	}
+
+	let importedCount = 0;
+	for (const documentId of documentIds) {
+		const filename = 'paperless-' + documentId + '.pdf';
+		const fileRef = app.vault.getAbstractFileByPath(folderPath + '/' + filename);
+		const fileExists = !!(fileRef) && fileRef instanceof TFile;
+		if (!fileExists) {
+			const shareLink = await getShareLink(settings, documentId);
+			if (shareLink) {
+				const response = await requestUrl({
+					url: shareLink.href,
+					method: 'GET'
+				});
+				await app.vault.createBinary(folderPath + '/' + filename, response.arrayBuffer);
+				importedCount++;
+			}
+		}
+	}
+
+	new Notice(`Imported ${importedCount} of ${documentIds.size} document(s).`);
 }
 
 async function searchPaperlessDocuments(settings: PluginSettings, searchQuery: string, tagIds: number[] = []): Promise<string[]> {

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Editor, EditorRange, MarkdownView, Modal, normalizePath, Notice, Plugin, PluginSettingTab, requestUrl, RequestUrlResponse, Setting, setIcon, TFolder, TFile } from 'obsidian';
+import { App, Editor, EditorRange, Modal, normalizePath, Notice, Plugin, PluginSettingTab, requestUrl, RequestUrlResponse, Setting, TFolder, TFile } from 'obsidian';
 import { escapeRegExp } from 'lodash';
 
 interface PluginSettings {
@@ -77,7 +77,7 @@ export default class ObsidianPaperless extends Plugin {
 }
 
 let cachedResult: RequestUrlResponse;
-let tagCache = new Map();
+const tagCache = new Map();
 
 async function testConnection(settings: PluginSettings) {
 	new Notice("Testing connection to " + settings.paperlessUrl)
@@ -118,7 +118,7 @@ async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) 
 		}
 	})
 	for (let i = 0; i < tagResult.json['results'].length; i++) {
-		let current = tagResult.json['results'][i];
+		const current = tagResult.json['results'][i];
 		tagCache.set(current['id'], current);
 	}
 	if(!silent) {
@@ -204,7 +204,7 @@ async function getExistingShareLink(settings: PluginSettings, documentId: string
 			console.error("An exception occurred in getExistingShareLink. Response: " + result);
 			return null;
 		}
-		for (let item of result.json) {
+		for (const item of result.json) {
 			if (item['expiration'] == null)  {
 				return new URL(settings.paperlessUrl + '/share/' + item['slug']);
 			}
@@ -395,7 +395,7 @@ class DocumentSelectorModal extends Modal {
 			}
 		})
 		imgElement.src = URL.createObjectURL(new Blob([result.arrayBuffer]));
-	};
+	}
 
 	async displayTags(tagDiv: HTMLDivElement, documentId: string) {
 		const thumbUrl = this.settings.paperlessUrl + '/api/documents/' + documentId + '/';
@@ -413,7 +413,7 @@ class DocumentSelectorModal extends Modal {
 			tagStr.setCssStyles({color: tagData['text_color'], fontSize: '0.7em'});
 			currentTag.setCssStyles({background: tagData['color'], borderRadius: '8px', padding: '2px', marginTop: '1px', marginRight: '5px'})
 		}
-	};
+	}
 
 	async onOpen() {
 		const {contentEl} = this;
@@ -514,7 +514,7 @@ class DocumentSelectorModal extends Modal {
 		};
 
 		const totalWidth = contentEl.innerWidth;
-		this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:String, b:String) => {return +a - +b}).reverse();
+		this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:string, b:string) => {return +a - +b}).reverse();
 		const totalAssets = this.availableDocumentIds.length;
 
 		// Create scroll container
@@ -545,7 +545,7 @@ class DocumentSelectorModal extends Modal {
 
 			if (searchQuery === '' && this.selectedTags.size === 0) {
 				// Reset to cached results
-				this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:String, b:String) => {return +a - +b}).reverse();
+				this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:string, b:string) => {return +a - +b}).reverse();
 			} else {
 				// Perform search
 				searchInput.disabled = true;
@@ -555,7 +555,7 @@ class DocumentSelectorModal extends Modal {
 				try {
 					const tagIds = Array.from(this.selectedTags);
 					const searchResults = await searchPaperlessDocuments(this.settings, searchQuery, tagIds);
-					this.availableDocumentIds = searchResults.sort((a:String, b:String) => {return +a - +b}).reverse();
+					this.availableDocumentIds = searchResults.sort((a:string, b:string) => {return +a - +b}).reverse();
 				} catch (error) {
 					new Notice('Failed to search documents');
 					console.error('Search failed:', error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -835,9 +835,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -907,9 +907,9 @@
 			"peer": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1004,9 +1004,9 @@
 			"peer": true
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1480,9 +1480,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true
@@ -1709,10 +1709,20 @@
 			"peer": true
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1790,9 +1800,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -1828,9 +1838,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -2003,9 +2013,9 @@
 			}
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
This includes: 

- Command to get referenced, but missing in vault, documents
- replaceUrlWithDoc command now works with `[[paperless-{id}.pdf]]`
- Toggle between embedding and linking paperlessdocument (toggle the `!` before `[[`) 
- fixed some linting errors/warnings
- doccreation now prefers archived version before original