### PR TITLE
fix: preserve external PDF references and harden document imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This assumes you have a working version of [paperless-ngx](https://github.com/pa
 You must also have the ✨amazing✨ [PDF++](https://github.com/RyotaUshio/obsidian-pdf-plus) plugin installed!
 
 ## How it works
-This plugin interacts with your paperless instance to enable seamless viewing of your documents within Obsidian. When you click on a document to import it will generate a share link from paperless and embed it into a *external PDF file*. Read more [here](https://ryotaushio.github.io/obsidian-pdf-plus/external-pdf-files.html). You can now view that document as though it was natively loaded in your vault, without needing to worry about local or remote storage limits.
+This plugin interacts with your paperless instance to enable seamless viewing of your documents within Obsidian. When you click on a document to import it, it generates a PDF++ dummy `.pdf` file containing only the public Paperless share URL. The actual PDF binary data is not stored in your Obsidian vault. Read more [here](https://ryotaushio.github.io/obsidian-pdf-plus/external-pdf-files.html).
 
 ## Setup
 
@@ -29,7 +29,8 @@ This plugin interacts with your paperless instance to enable seamless viewing of
 4. Fill in the following settings:
     - Paperless URL: full url to your paperless-ngx instance. Do not include the trailing `/`.
     - Paperless authentication token: token you obtained in step 1.
-    - Document storage path: location you would like to save references to these PDFs.
+    - Document storage path: optional location for the PDF++ dummy files. If left empty, references are created in the vault root.
+    - Embed documents: when enabled, inserted documents use `![[paperless-ID.pdf]]`; when disabled, they use `[[paperless-ID.pdf]]`.
 5. Click "Test connection" to confirm connectivity. If any errors appear, you can view them in the console. Open the console using `cmd+option+i` (MacOS) or `ctrl+shift+i` (Windows). 
 
 ## Usage
@@ -50,6 +51,12 @@ The standard insertion command. Please note you must have an open editor focused
 The "Insert document" command caches some information such as available documents, tags, and other metadata when it is first run. If you find that new documents or changes are not showing up in the document selection modal, running this command will refresh the caches.
 
 #### Replace URL with document
-This command replaces a url in a note with an embed of the document. To use:
+This command replaces a url in a note with a document reference. It recognizes both Paperless URLs and existing `[[paperless-ID.pdf]]` references. To use:
 1. Move your cursor onto a paperless url in a note. The url should be of the form `http://ip:port/api/documents/id/preview/` or `http://ip:port/documents/id/details`
 1. Run this command
+
+#### Import missing documents
+This command searches the current Markdown document for `[[paperless-ID.pdf]]` and `![[paperless-ID.pdf]]` references and creates any missing PDF++ dummy files. It does not download PDF binary data into the vault.
+
+## Manual testing
+Test documents with multiple pages and documents with tags. Also test documents whose Paperless share links are missing.

--- a/main.ts
+++ b/main.ts
@@ -154,6 +154,7 @@ async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) 
 	// Cache data relating to tags
 	const tagUrl = new URL(settings.paperlessUrl + '/api/tags/?format=json');
 	const tagResult = await fetchAllPages<Record<string, any>>(tagUrl, settings);
+	tagCache.clear();
 	for (let i = 0; i < tagResult.results.length; i++) {
 		const current = tagResult.results[i];
 		tagCache.set(current['id'], current);
@@ -749,6 +750,8 @@ class DocumentSelectorModal extends Modal {
 	}
 
 	onClose() {
+		this.isLoading = false;
+		this.scrollContainer = null;
 		this.searchGeneration++;
 		if (this.scrollTimeout) {
 			clearTimeout(this.scrollTimeout);

--- a/main.ts
+++ b/main.ts
@@ -167,6 +167,15 @@ function searchPaperlessUrl(editor: Editor, settings: PluginSettings): Paperless
 		}
 	}
 
+	// also match [[paperless-{id}.pdf]] wiki links
+	const wikiLinkMatch = text.match(/\[\[paperless-(\d+)\.pdf\]\]/);
+	if (wikiLinkMatch) {
+		return {
+			documentId: wikiLinkMatch[1],
+			range: wordRange
+		};
+	}
+
 	// nothing found
 	return null;
 }

--- a/main.ts
+++ b/main.ts
@@ -641,7 +641,7 @@ class DocumentSelectorModal extends Modal {
 			imgElement.width = (totalWidth / 2) - 5;
 			imgElement.style.cursor = 'pointer';
 
-			imgElement.onclick = () => {
+			imgElement.onclick = async () => {
 				const cursor = this.editor.getCursor();
 				const documentInfo: PaperlessInsertionData = {
 					documentId: documentId,
@@ -650,8 +650,8 @@ class DocumentSelectorModal extends Modal {
 						to: { line: cursor.line, ch: cursor.ch }
 					}
 				}
-				createDocument(this.app, this.editor, this.settings, documentInfo);
-				overallDiv.setCssStyles({opacity: '0.5'});
+				await createDocument(this.app, this.editor, this.settings, documentInfo);
+				this.close();
 			};
 
 			imgElement.onerror = () => {

--- a/main.ts
+++ b/main.ts
@@ -216,7 +216,9 @@ async function getExistingShareLink(settings: PluginSettings, documentId: string
 	return null;
 }
 
-async function createShareLink(settings: PluginSettings, documentId: string) {
+type ShareLinkFileVersion = 'archive' | 'original';
+
+async function createShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion) {
 	const url = new URL(settings.paperlessUrl + '/api/share_links/');
 	let result;
 	try {
@@ -224,36 +226,41 @@ async function createShareLink(settings: PluginSettings, documentId: string) {
 			url: url.toString(),
 			method: 'POST',
 			contentType: 'application/json',
-			body: '{"document":' + documentId + ',"file_version":"original"}',
+			body: JSON.stringify({ document: documentId, file_version: fileVersion }),
 			headers: {
 				'Authorization': 'token ' + settings.paperlessAuthToken
 			}
 		})
-		if (result.status != 201) {
-			console.error("An exception occurred in createShareLink. Response: " + result);
-		}
+		return result.status === 201;
 	} catch (e) {
 		console.error("An exception occurred in createShareLink. Exception: " + e + " and response " + result);
+		return false;
 	}
 }
 
-async function getShareLink(settings: PluginSettings, documentId: string) {
-	let link = await getExistingShareLink(settings, documentId);
-	if (!link) {
-		createShareLink(settings, documentId);
-		link = await getExistingShareLink(settings, documentId);
-		if (link == null) {
-			// Sometimes this takes a while, give it five immediate retries before giving up.
-			for (let i = 0; i < 5; i++) {
-				link = await getExistingShareLink(settings, documentId);
-				if (link) {
-					break;
-				}
-			}
+async function findShareLink(settings: PluginSettings, documentId: string, attempts = 1) {
+	for (let i = 0; i < attempts; i++) {
+		const link = await getExistingShareLink(settings, documentId);
+		if (link) {
+			return link;
 		}
 	}
 
-	return link;
+	return null;
+}
+
+async function createAndFindShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion) {
+	if (await createShareLink(settings, documentId, fileVersion)) {
+		return await findShareLink(settings, documentId, 6);
+	}
+
+	return null;
+}
+
+async function getShareLink(settings: PluginSettings, documentId: string) {
+	return await findShareLink(settings, documentId)
+		?? await createAndFindShareLink(settings, documentId, 'archive')
+		?? await createAndFindShareLink(settings, documentId, 'original');
 }
 
 // Heavily inspired by https://github.com/RyotaUshio/obsidian-pdf-plus/blob/127ea5b94bb8f8fa0d4c66bcd77b3809caa50b21/src/modals/external-pdf-modals.ts#L249

--- a/main.ts
+++ b/main.ts
@@ -38,7 +38,7 @@ export default class ObsidianPaperless extends Plugin {
 			editorCallback: (editor: Editor) => {
 				const paperlessUrl = searchPaperlessUrl(editor, this.settings);
 				if (paperlessUrl) {
-					createDocument(editor, this.settings, paperlessUrl);
+					createDocument(this.app, editor, this.settings, paperlessUrl);
 				}
 			}
 		});
@@ -85,7 +85,7 @@ async function testConnection(settings: PluginSettings) {
 	} catch(exception) {
 		new Notice("Failed to connect to " + settings.paperlessUrl + " - check the console for additional information.")
 		console.log("Failed connection to " + url + " with error: " + exception)
-	}	
+	}
 }
 
 async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) {
@@ -112,7 +112,7 @@ async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) 
 		tagCache.set(current['id'], current);
 	}
 	if(!silent) {
-		new Notice('Paperless cache refresh completed. Found ' + cachedResult.json['all'].length + ' documents and ' + tagCache.size + ' tags.');
+		new Notice('Paperless cache refresh completed. Found ' + cachedResult.json['results'].length + ' documents and ' + tagCache.size + ' tags.');
 	}
 }
 
@@ -238,24 +238,28 @@ async function getShareLink(settings: PluginSettings, documentId: string) {
 }
 
 // Heavily inspired by https://github.com/RyotaUshio/obsidian-pdf-plus/blob/127ea5b94bb8f8fa0d4c66bcd77b3809caa50b21/src/modals/external-pdf-modals.ts#L249
-async function createDocument(editor: Editor, settings: PluginSettings, paperlessUrl: PaperlessInsertionData) {
+async function createDocument(app: App, editor: Editor, settings: PluginSettings, paperlessUrl: PaperlessInsertionData) {
 	// Create the parent folder
 	const folderPath = normalizePath(settings.documentStoragePath);
 	if (folderPath) {
-		const folderRef = this.app.vault.getAbstractFileByPath(folderPath);
+		const folderRef = app.vault.getAbstractFileByPath(folderPath);
 		const folderExists = !!(folderRef) && folderRef instanceof TFolder;
 		if (!folderExists) {
-			await this.app.vault.createFolder(folderPath);
+			await app.vault.createFolder(folderPath);
 		}
 	}
-	
+
 	const filename = 'paperless-' + paperlessUrl.documentId + '.pdf';
-	const fileRef = this.app.vault.getAbstractFileByPath(folderPath + '/' + filename); 
+	const fileRef = app.vault.getAbstractFileByPath(folderPath + '/' + filename);
 	const fileExists = !!(fileRef) && fileRef instanceof TFile;
 	if (!fileExists) {
 		const shareLink = await getShareLink(settings, paperlessUrl.documentId);
 		if (shareLink) {
-			await this.app.vault.create(folderPath + '/' + filename, shareLink.href);
+			const response = await requestUrl({
+				url: shareLink.href,
+				method: 'GET'
+			});
+			await app.vault.createBinary(folderPath + '/' + filename, response.arrayBuffer);
 		}
 	}
 
@@ -279,8 +283,8 @@ async function searchPaperlessDocuments(settings: PluginSettings, searchQuery: s
 				'Authorization': 'token ' + settings.paperlessAuthToken
 			}
 		});
-		if (result.status === 200 && result.json['all']) {
-			return result.json['all'];
+		if (result.status === 200 && result.json['results']) {
+			return result.json['results'].map((d: Record<string, any>) => d.id.toString());
 		}
 		console.error('Search returned unexpected response:', result);
 		return [];
@@ -325,7 +329,7 @@ class DocumentSelectorModal extends Modal {
 			headers: {
 				'Authorization': 'token ' + this.settings.paperlessAuthToken
 			}
-		})	
+		})
 		imgElement.src = URL.createObjectURL(new Blob([result.arrayBuffer]));
 	};
 
@@ -340,7 +344,7 @@ class DocumentSelectorModal extends Modal {
 		const tags = result.json['tags']
 		for (let x = 0; x < tags.length; x++) {
 			const currentTag = tagDiv.createDiv();
-			const tagData = tagCache.get(tags[x]);					
+			const tagData = tagCache.get(tags[x]);
 			const tagStr = currentTag.createEl('span', {text: tagData['name']});
 			tagStr.setCssStyles({color: tagData['text_color'], fontSize: '0.7em'});
 			currentTag.setCssStyles({background: tagData['color'], borderRadius: '8px', padding: '2px', marginTop: '1px', marginRight: '5px'})
@@ -446,7 +450,7 @@ class DocumentSelectorModal extends Modal {
 		};
 
 		const totalWidth = contentEl.innerWidth;
-		this.availableDocumentIds = cachedResult.json['all'].sort((a:String, b:String) => {return +a - +b}).reverse();
+		this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:String, b:String) => {return +a - +b}).reverse();
 		const totalAssets = this.availableDocumentIds.length;
 
 		// Create scroll container
@@ -474,16 +478,16 @@ class DocumentSelectorModal extends Modal {
 			// Debounce: wait 500ms after user stops typing
 			this.searchTimeout = window.setTimeout(async () => {
 				const searchQuery = (e.target as HTMLInputElement).value.trim();
-				
+
 			if (searchQuery === '' && this.selectedTags.size === 0) {
 				// Reset to cached results
-				this.availableDocumentIds = cachedResult.json['all'].sort((a:String, b:String) => {return +a - +b}).reverse();
+				this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:String, b:String) => {return +a - +b}).reverse();
 			} else {
 				// Perform search
 				searchInput.disabled = true;
 				loadingDiv.setText('Searching...');
 				loadingDiv.style.display = 'block';
-				
+
 				try {
 					const tagIds = Array.from(this.selectedTags);
 					const searchResults = await searchPaperlessDocuments(this.settings, searchQuery, tagIds);
@@ -501,12 +505,12 @@ class DocumentSelectorModal extends Modal {
 				this.loadedAssets.clear();
 				left.empty();
 				right.empty();
-				
+
 				// Scroll to top
 				if (this.scrollContainer) {
 					this.scrollContainer.scrollTop = 0;
 				}
-				
+
 			// Initial load: load more items to ensure scrollbar appears on large screens
 			const initialBatchSize = Math.max(this.batchSize * 3, 20);
 			this.loadBatch(left, right, totalWidth, this.availableDocumentIds, 0, Math.min(initialBatchSize, this.availableDocumentIds.length), loadingDiv);
@@ -566,30 +570,30 @@ class DocumentSelectorModal extends Modal {
 			const overallDiv = targetColumn.createDiv({cls: 'obsidian-paperless-overallDiv'});
 			const imageDiv = overallDiv.createDiv({cls: 'obsidian-paperless-imageDiv'});
 			const tagDiv = overallDiv.createDiv({cls: 'obsidian-paperless-tagDiv'});
-			
+
 			this.displayTags(tagDiv, documentId);
-			
+
 			const imgElement = imageDiv.createEl('img');
 			imgElement.width = (totalWidth / 2) - 5;
 			imgElement.style.cursor = 'pointer';
-			
+
 			imgElement.onclick = () => {
 				const cursor = this.editor.getCursor();
 				const documentInfo: PaperlessInsertionData = {
 					documentId: documentId,
-					range: { 
+					range: {
 						from: { line: cursor.line, ch: cursor.ch },
 						to: { line: cursor.line, ch: cursor.ch }
 					}
 				}
-				createDocument(this.editor, this.settings, documentInfo);
+				createDocument(this.app, this.editor, this.settings, documentInfo);
 				overallDiv.setCssStyles({opacity: '0.5'});
 			};
-			
+
 			imgElement.onerror = () => {
 				overallDiv.setText('Failed to load');
 			};
-			
+
 			this.displayThumbnail(imgElement, documentId);
 			this.loadedAssets.set(i, overallDiv);
 		}

--- a/main.ts
+++ b/main.ts
@@ -5,6 +5,7 @@ interface PluginSettings {
 	paperlessUrl: string;
 	paperlessAuthToken: string;
 	documentStoragePath: string;
+	embedDocuments: boolean;
 }
 
 interface PaperlessInsertionData {
@@ -15,7 +16,8 @@ interface PaperlessInsertionData {
 const DEFAULT_SETTINGS: PluginSettings = {
 	paperlessUrl: '',
 	paperlessAuthToken: '',
-	documentStoragePath: ''
+	documentStoragePath: '',
+	embedDocuments: true
 }
 
 export default class ObsidianPaperless extends Plugin {
@@ -280,7 +282,8 @@ async function createDocument(app: App, editor: Editor, settings: PluginSettings
 		}
 	}
 
-	editor.replaceRange('![[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
+	const linkPrefix = settings.embedDocuments ? '![' : '[';
+	editor.replaceRange(linkPrefix + '[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
 }
 
 async function importMissingDocuments(app: App, editor: Editor, settings: PluginSettings) {
@@ -720,6 +723,15 @@ class SettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.documentStoragePath)
 				.onChange(async (value) => {
 					this.plugin.settings.documentStoragePath = value;
+					await this.plugin.saveSettings();
+				}));
+		new Setting(containerEl)
+			.setName('Embed documents')
+			.setDesc('When enabled, new documents are inserted as embedded PDFs (![[...]]). Otherwise as links ([[...]]).')
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.embedDocuments)
+				.onChange(async (value) => {
+					this.plugin.settings.embedDocuments = value;
 					await this.plugin.saveSettings();
 				}));
 		new Setting(containerEl)

--- a/main.ts
+++ b/main.ts
@@ -218,6 +218,34 @@ async function getExistingShareLink(settings: PluginSettings, documentId: string
 
 type ShareLinkFileVersion = 'archive' | 'original';
 
+async function getExistingShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion) {
+	const url = new URL(settings.paperlessUrl + '/api/documents/' + documentId + '/share_links/?format=json');
+	let result;
+	try {
+		result = await requestUrl({
+			url: url.toString(),
+			headers: {
+				'Authorization': 'token ' + settings.paperlessAuthToken
+			}
+		})
+		if (result.status != 200) {
+			console.error("An exception occurred in getExistingShareLink. Response: " + result);
+			return null;
+		}
+		for (const item of result.json) {
+			const expiration = item['expiration'];
+			if (item['file_version'] == fileVersion && item['slug'] &&
+				(expiration == null || new Date(expiration).getTime() > Date.now())) {
+				return new URL(settings.paperlessUrl + '/share/' + item['slug']);
+			}
+		}
+	} catch (e) {
+		console.error("An exception occurred in getExistingShareLink. Exception: " + e + " and response " + result);
+	}
+
+	return null;
+}
+
 async function createShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion) {
 	const url = new URL(settings.paperlessUrl + '/api/share_links/');
 	let result;
@@ -231,18 +259,24 @@ async function createShareLink(settings: PluginSettings, documentId: string, fil
 				'Authorization': 'token ' + settings.paperlessAuthToken
 			}
 		})
-		return result.status === 201;
+		if (result.status === 201 && result.json['slug']) {
+			return result.json['slug'];
+		}
 	} catch (e) {
 		console.error("An exception occurred in createShareLink. Exception: " + e + " and response " + result);
-		return false;
 	}
+
+	return null;
 }
 
-async function findShareLink(settings: PluginSettings, documentId: string, attempts = 1) {
+async function findShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion, attempts = 1) {
 	for (let i = 0; i < attempts; i++) {
-		const link = await getExistingShareLink(settings, documentId);
+		const link = await getExistingShareLink(settings, documentId, fileVersion);
 		if (link) {
 			return link;
+		}
+		if (i < attempts - 1) {
+			await new Promise(resolve => setTimeout(resolve, 250));
 		}
 	}
 
@@ -250,47 +284,60 @@ async function findShareLink(settings: PluginSettings, documentId: string, attem
 }
 
 async function createAndFindShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion) {
-	if (await createShareLink(settings, documentId, fileVersion)) {
-		return await findShareLink(settings, documentId, 6);
+	const slug = await createShareLink(settings, documentId, fileVersion);
+	if (slug) {
+		return new URL(settings.paperlessUrl + '/share/' + slug);
 	}
 
-	return null;
+	return await findShareLink(settings, documentId, fileVersion, 6);
 }
 
 async function getShareLink(settings: PluginSettings, documentId: string) {
-	return await findShareLink(settings, documentId)
+	return await findShareLink(settings, documentId, 'archive')
 		?? await createAndFindShareLink(settings, documentId, 'archive')
+		?? await findShareLink(settings, documentId, 'original')
 		?? await createAndFindShareLink(settings, documentId, 'original');
 }
 
+function getDocumentPath(settings: PluginSettings, documentId: string) {
+	const folderPath = normalizePath(settings.documentStoragePath).replace(/^\/+/, '');
+	const filename = 'paperless-' + documentId + '.pdf';
+	return folderPath ? folderPath + '/' + filename : filename;
+}
+
 // Heavily inspired by https://github.com/RyotaUshio/obsidian-pdf-plus/blob/127ea5b94bb8f8fa0d4c66bcd77b3809caa50b21/src/modals/external-pdf-modals.ts#L249
-async function createDocument(app: App, editor: Editor, settings: PluginSettings, paperlessUrl: PaperlessInsertionData) {
-	// Create the parent folder
-	const folderPath = normalizePath(settings.documentStoragePath);
-	if (folderPath) {
-		const folderRef = app.vault.getAbstractFileByPath(folderPath);
-		const folderExists = !!(folderRef) && folderRef instanceof TFolder;
-		if (!folderExists) {
-			await app.vault.createFolder(folderPath);
+async function createDocument(app: App, editor: Editor, settings: PluginSettings, paperlessUrl: PaperlessInsertionData): Promise<boolean> {
+	try {
+		// Create the parent folder
+		const folderPath = normalizePath(settings.documentStoragePath).replace(/^\/+/, '');
+		if (folderPath) {
+			const folderRef = app.vault.getAbstractFileByPath(folderPath);
+			const folderExists = !!(folderRef) && folderRef instanceof TFolder;
+			if (!folderExists) {
+				await app.vault.createFolder(folderPath);
+			}
 		}
-	}
 
-	const filename = 'paperless-' + paperlessUrl.documentId + '.pdf';
-	const fileRef = app.vault.getAbstractFileByPath(folderPath + '/' + filename);
-	const fileExists = !!(fileRef) && fileRef instanceof TFile;
-	if (!fileExists) {
-		const shareLink = await getShareLink(settings, paperlessUrl.documentId);
-		if (shareLink) {
-			const response = await requestUrl({
-				url: shareLink.href,
-				method: 'GET'
-			});
-			await app.vault.createBinary(folderPath + '/' + filename, response.arrayBuffer);
+		const filename = 'paperless-' + paperlessUrl.documentId + '.pdf';
+		const documentPath = getDocumentPath(settings, paperlessUrl.documentId);
+		const fileRef = app.vault.getAbstractFileByPath(documentPath);
+		const fileExists = !!(fileRef) && fileRef instanceof TFile;
+		if (!fileExists) {
+			const shareLink = await getShareLink(settings, paperlessUrl.documentId);
+			if (!shareLink) {
+				throw new Error('No usable share link found');
+			}
+			await app.vault.create(documentPath, shareLink.href);
 		}
-	}
 
-	const linkPrefix = settings.embedDocuments ? '![' : '[';
-	editor.replaceRange(linkPrefix + '[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
+		const linkPrefix = settings.embedDocuments ? '![' : '[';
+		editor.replaceRange(linkPrefix + '[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
+		return true;
+	} catch (error) {
+		console.error('Failed to create Paperless document:', error);
+		new Notice('Failed to import Paperless document.');
+		return false;
+	}
 }
 
 async function importMissingDocuments(app: App, editor: Editor, settings: PluginSettings) {
@@ -307,7 +354,8 @@ async function importMissingDocuments(app: App, editor: Editor, settings: Plugin
 		return;
 	}
 
-	const folderPath = normalizePath(settings.documentStoragePath);
+	// Create the parent folder
+	const folderPath = normalizePath(settings.documentStoragePath).replace(/^\/+/, '');
 	if (folderPath) {
 		const folderRef = app.vault.getAbstractFileByPath(folderPath);
 		const folderExists = !!(folderRef) && folderRef instanceof TFolder;
@@ -317,24 +365,27 @@ async function importMissingDocuments(app: App, editor: Editor, settings: Plugin
 	}
 
 	let importedCount = 0;
+	let failedCount = 0;
 	for (const documentId of documentIds) {
-		const filename = 'paperless-' + documentId + '.pdf';
-		const fileRef = app.vault.getAbstractFileByPath(folderPath + '/' + filename);
-		const fileExists = !!(fileRef) && fileRef instanceof TFile;
-		if (!fileExists) {
-			const shareLink = await getShareLink(settings, documentId);
-			if (shareLink) {
-				const response = await requestUrl({
-					url: shareLink.href,
-					method: 'GET'
-				});
-				await app.vault.createBinary(folderPath + '/' + filename, response.arrayBuffer);
+		try {
+			const documentPath = getDocumentPath(settings, documentId);
+			const fileRef = app.vault.getAbstractFileByPath(documentPath);
+			const fileExists = !!(fileRef) && fileRef instanceof TFile;
+			if (!fileExists) {
+				const shareLink = await getShareLink(settings, documentId);
+				if (!shareLink) {
+					throw new Error('No usable share link found');
+				}
+				await app.vault.create(documentPath, shareLink.href);
 				importedCount++;
 			}
+		} catch (error) {
+			failedCount++;
+			console.error('Failed to import Paperless document ' + documentId + ':', error);
 		}
 	}
 
-	new Notice(`Imported ${importedCount} of ${documentIds.size} document(s).`);
+	new Notice(`Imported ${importedCount} of ${documentIds.size} document(s).${failedCount ? ` Failed: ${failedCount}.` : ''}`);
 }
 
 async function searchPaperlessDocuments(settings: PluginSettings, searchQuery: string, tagIds: number[] = []): Promise<string[]> {
@@ -657,8 +708,10 @@ class DocumentSelectorModal extends Modal {
 						to: { line: cursor.line, ch: cursor.ch }
 					}
 				}
-				await createDocument(this.app, this.editor, this.settings, documentInfo);
-				this.close();
+				const created = await createDocument(this.app, this.editor, this.settings, documentInfo);
+				if (created) {
+					this.close();
+				}
 			};
 
 			imgElement.onerror = () => {

--- a/main.ts
+++ b/main.ts
@@ -190,31 +190,6 @@ function searchPaperlessUrl(editor: Editor, settings: PluginSettings): Paperless
 	return null;
 }
 
-async function getExistingShareLink(settings: PluginSettings, documentId: string) {
-	const url = new URL(settings.paperlessUrl + '/api/documents/' + documentId + '/share_links/?format=json');
-	let result;
-	try {
-		result = await requestUrl({
-			url: url.toString(),
-			headers: {
-				'Authorization': 'token ' + settings.paperlessAuthToken
-			}
-		})
-		if (result.status != 200) {
-			console.error("An exception occurred in getExistingShareLink. Response: " + result);
-			return null;
-		}
-		for (const item of result.json) {
-			if (item['expiration'] == null)  {
-				return new URL(settings.paperlessUrl + '/share/' + item['slug']);
-			}
-		}
-	} catch (e) {
-		console.error("An exception occurred in getExistingShareLink. Exception: " + e + " and response " + result);
-	}
-
-	return null;
-}
 
 type ShareLinkFileVersion = 'archive' | 'original';
 
@@ -270,6 +245,7 @@ async function createShareLink(settings: PluginSettings, documentId: string, fil
 }
 
 async function findShareLink(settings: PluginSettings, documentId: string, fileVersion: ShareLinkFileVersion, attempts = 1) {
+	// Sometimes this takes a while, give it five immediate retries before giving up.
 	for (let i = 0; i < attempts; i++) {
 		const link = await getExistingShareLink(settings, documentId, fileVersion);
 		if (link) {

--- a/main.ts
+++ b/main.ts
@@ -96,7 +96,7 @@ async function fetchAllPages<T>(initialUrl: URL, settings: PluginSettings): Prom
 		}
 		visitedUrls.add(nextUrl);
 
-		const result = await requestUrl({
+		const result: RequestUrlResponse = await requestUrl({
 			url: nextUrl,
 			headers: {
 				'Authorization': 'token ' + settings.paperlessAuthToken
@@ -108,7 +108,7 @@ async function fetchAllPages<T>(initialUrl: URL, settings: PluginSettings): Prom
 			throw new Error('Paperless returned HTTP ' + result.status);
 		}
 
-		const payload = result.json;
+		const payload: Record<string, any> = result.json;
 		if (!payload || !Array.isArray(payload.results) ||
 			!Object.prototype.hasOwnProperty.call(payload, 'next') ||
 			(payload.next !== null && typeof payload.next !== 'string')) {

--- a/main.ts
+++ b/main.ts
@@ -52,6 +52,14 @@ export default class ObsidianPaperless extends Plugin {
 			}
 		});
 
+		this.addCommand({
+			id: 'import-missing-paperless',
+			name: 'Import missing documents',
+			editorCallback: async (editor: Editor) => {
+				await importMissingDocuments(this.app, editor, this.settings);
+			}
+		});
+
 		this.addSettingTab(new SettingTab(this.app, this));
 	}
 
@@ -273,6 +281,50 @@ async function createDocument(app: App, editor: Editor, settings: PluginSettings
 	}
 
 	editor.replaceRange('![[' + filename + ']]', paperlessUrl.range.from, paperlessUrl.range.to);
+}
+
+async function importMissingDocuments(app: App, editor: Editor, settings: PluginSettings) {
+	const content = editor.getValue();
+	const pattern = /!?\[\[paperless-(\d+)\.pdf\]\]/g;
+	const documentIds = new Set<string>();
+	let match;
+	while ((match = pattern.exec(content)) !== null) {
+		documentIds.add(match[1]);
+	}
+
+	if (documentIds.size === 0) {
+		new Notice('No paperless document links found in this note.');
+		return;
+	}
+
+	const folderPath = normalizePath(settings.documentStoragePath);
+	if (folderPath) {
+		const folderRef = app.vault.getAbstractFileByPath(folderPath);
+		const folderExists = !!(folderRef) && folderRef instanceof TFolder;
+		if (!folderExists) {
+			await app.vault.createFolder(folderPath);
+		}
+	}
+
+	let importedCount = 0;
+	for (const documentId of documentIds) {
+		const filename = 'paperless-' + documentId + '.pdf';
+		const fileRef = app.vault.getAbstractFileByPath(folderPath + '/' + filename);
+		const fileExists = !!(fileRef) && fileRef instanceof TFile;
+		if (!fileExists) {
+			const shareLink = await getShareLink(settings, documentId);
+			if (shareLink) {
+				const response = await requestUrl({
+					url: shareLink.href,
+					method: 'GET'
+				});
+				await app.vault.createBinary(folderPath + '/' + filename, response.arrayBuffer);
+				importedCount++;
+			}
+		}
+	}
+
+	new Notice(`Imported ${importedCount} of ${documentIds.size} document(s).`);
 }
 
 async function searchPaperlessDocuments(settings: PluginSettings, searchQuery: string, tagIds: number[] = []): Promise<string[]> {

--- a/main.ts
+++ b/main.ts
@@ -79,6 +79,53 @@ export default class ObsidianPaperless extends Plugin {
 let cachedResult: RequestUrlResponse;
 const tagCache = new Map();
 
+interface PaginatedResponse<T> {
+	response: RequestUrlResponse;
+	results: T[];
+}
+
+async function fetchAllPages<T>(initialUrl: URL, settings: PluginSettings): Promise<PaginatedResponse<T>> {
+	const visitedUrls = new Set<string>();
+	let nextUrl: string | null = initialUrl.toString();
+	let firstResponse: RequestUrlResponse | null = null;
+	const results: T[] = [];
+
+	while (nextUrl !== null) {
+		if (visitedUrls.has(nextUrl)) {
+			throw new Error('Pagination loop detected');
+		}
+		visitedUrls.add(nextUrl);
+
+		const result = await requestUrl({
+			url: nextUrl,
+			headers: {
+				'Authorization': 'token ' + settings.paperlessAuthToken
+			}
+		});
+		firstResponse ??= result;
+
+		if (result.status < 200 || result.status >= 300) {
+			throw new Error('Paperless returned HTTP ' + result.status);
+		}
+
+		const payload = result.json;
+		if (!payload || !Array.isArray(payload.results) ||
+			!Object.prototype.hasOwnProperty.call(payload, 'next') ||
+			(payload.next !== null && typeof payload.next !== 'string')) {
+			throw new Error('Paperless returned an invalid paginated response');
+		}
+
+		results.push(...payload.results);
+		nextUrl = payload.next === null ? null : new URL(payload.next, nextUrl).toString();
+	}
+
+	if (!firstResponse) {
+		throw new Error('Paperless returned no response');
+	}
+
+	return {response: firstResponse, results};
+}
+
 async function testConnection(settings: PluginSettings) {
 	new Notice("Testing connection to " + settings.paperlessUrl)
 	const url = new URL(settings.paperlessUrl + '/api/documents/');
@@ -100,25 +147,15 @@ async function testConnection(settings: PluginSettings) {
 
 async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) {
 	const url = new URL(settings.paperlessUrl + '/api/documents/?format=json');
-	const result = await requestUrl({
-		url: url.toString(),
-		headers: {
-			'Authorization': 'token ' + settings.paperlessAuthToken
-		}
-	})
-	cachedResult = result;
+	const documentResult = await fetchAllPages<Record<string, any>>(url, settings);
+	cachedResult = documentResult.response;
+	cachedResult.json['results'] = documentResult.results;
 
 	// Cache data relating to tags
 	const tagUrl = new URL(settings.paperlessUrl + '/api/tags/?format=json');
-	const tagResult = await requestUrl({
-		url: tagUrl.toString(),
-		headers: {
-			"accept": "application/json; version=5",
-			'Authorization': 'token ' + settings.paperlessAuthToken
-		}
-	})
-	for (let i = 0; i < tagResult.json['results'].length; i++) {
-		const current = tagResult.json['results'][i];
+	const tagResult = await fetchAllPages<Record<string, any>>(tagUrl, settings);
+	for (let i = 0; i < tagResult.results.length; i++) {
+		const current = tagResult.results[i];
 		tagCache.set(current['id'], current);
 	}
 	if(!silent) {
@@ -207,7 +244,8 @@ async function getExistingShareLink(settings: PluginSettings, documentId: string
 			console.error("An exception occurred in getExistingShareLink. Response: " + result);
 			return null;
 		}
-		for (const item of result.json) {
+		const shareLinks = await fetchAllPages<Record<string, any>>(url, settings);
+		for (const item of shareLinks.results) {
 			const expiration = item['expiration'];
 			if (item['file_version'] == fileVersion && item['slug'] &&
 				(expiration == null || new Date(expiration).getTime() > Date.now())) {
@@ -367,7 +405,7 @@ async function importMissingDocuments(app: App, editor: Editor, settings: Plugin
 async function searchPaperlessDocuments(settings: PluginSettings, searchQuery: string, tagIds: number[] = []): Promise<string[]> {
 	let urlStr = settings.paperlessUrl + '/api/documents/?format=json';
 	if (searchQuery) {
-		urlStr += '&title_content=' + encodeURIComponent(searchQuery);
+		urlStr += '&text=' + encodeURIComponent(searchQuery);
 	}
 	if (tagIds.length > 0) {
 		urlStr += '&tags__id__all=' + tagIds.join(',');
@@ -375,17 +413,8 @@ async function searchPaperlessDocuments(settings: PluginSettings, searchQuery: s
 	console.log("Querying " + urlStr)
 	const url = new URL(urlStr);
 	try {
-		const result = await requestUrl({
-			url: url.toString(),
-			headers: {
-				'Authorization': 'token ' + settings.paperlessAuthToken
-			}
-		});
-		if (result.status === 200 && result.json['results']) {
-			return result.json['results'].map((d: Record<string, any>) => d.id.toString());
-		}
-		console.error('Search returned unexpected response:', result);
-		return [];
+		const result = await fetchAllPages<Record<string, any>>(url, settings);
+		return result.results.map((d: Record<string, any>) => d.id.toString());
 	} catch (error) {
 		console.error('Error searching Paperless:', error);
 		throw error;
@@ -402,6 +431,7 @@ class DocumentSelectorModal extends Modal {
 	isLoading: boolean;
 	scrollTimeout: number | null;
 	searchTimeout: number | null;
+	searchGeneration: number;
 	selectedTags: Set<number>;
 	availableDocumentIds: string[];
 
@@ -416,6 +446,7 @@ class DocumentSelectorModal extends Modal {
 		this.isLoading = false;
 		this.scrollTimeout = null;
 		this.searchTimeout = null;
+		this.searchGeneration = 0;
 		this.selectedTags = new Set();
 		this.availableDocumentIds = [];
 	}
@@ -443,6 +474,9 @@ class DocumentSelectorModal extends Modal {
 		for (let x = 0; x < tags.length; x++) {
 			const currentTag = tagDiv.createDiv();
 			const tagData = tagCache.get(tags[x]);
+			if (!tagData) {
+				continue;
+			}
 			const tagStr = currentTag.createEl('span', {text: tagData['name']});
 			tagStr.setCssStyles({color: tagData['text_color'], fontSize: '0.7em'});
 			currentTag.setCssStyles({background: tagData['color'], borderRadius: '8px', padding: '2px', marginTop: '1px', marginRight: '5px'})
@@ -569,12 +603,14 @@ class DocumentSelectorModal extends Modal {
 		loadingDiv.style.display = 'none';
 
 		searchInput.addEventListener('input', async (e) => {
+			const requestId = ++this.searchGeneration;
 			if (this.searchTimeout) {
 				clearTimeout(this.searchTimeout);
 			}
 
 			// Debounce: wait 500ms after user stops typing
 			this.searchTimeout = window.setTimeout(async () => {
+				if (requestId !== this.searchGeneration) return;
 				const searchQuery = (e.target as HTMLInputElement).value.trim();
 
 			if (searchQuery === '' && this.selectedTags.size === 0) {
@@ -589,14 +625,18 @@ class DocumentSelectorModal extends Modal {
 				try {
 					const tagIds = Array.from(this.selectedTags);
 					const searchResults = await searchPaperlessDocuments(this.settings, searchQuery, tagIds);
+					if (requestId !== this.searchGeneration) return;
 					this.availableDocumentIds = searchResults.sort((a:string, b:string) => {return +a - +b}).reverse();
 				} catch (error) {
+					if (requestId !== this.searchGeneration) return;
 					new Notice('Failed to search documents');
 					console.error('Search failed:', error);
 					loadingDiv.style.display = 'none';
 				} finally {
-					searchInput.disabled = false;
-					loadingDiv.style.display = 'none';
+					if (requestId === this.searchGeneration) {
+						searchInput.disabled = false;
+						loadingDiv.style.display = 'none';
+					}
 				}
 			}				// Reset and reload modal content
 				this.currentPage = 0;
@@ -709,6 +749,7 @@ class DocumentSelectorModal extends Modal {
 	}
 
 	onClose() {
+		this.searchGeneration++;
 		if (this.scrollTimeout) {
 			clearTimeout(this.scrollTimeout);
 		}

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Editor, EditorRange, MarkdownView, Modal, normalizePath, Notice, Plugin, PluginSettingTab, requestUrl, RequestUrlResponse, Setting, setIcon, TFolder, TFile } from 'obsidian';
+import { App, Editor, EditorRange, Modal, normalizePath, Notice, Plugin, PluginSettingTab, requestUrl, RequestUrlResponse, Setting, TFolder, TFile } from 'obsidian';
 import { escapeRegExp } from 'lodash';
 
 interface PluginSettings {
@@ -77,7 +77,7 @@ export default class ObsidianPaperless extends Plugin {
 }
 
 let cachedResult: RequestUrlResponse;
-let tagCache = new Map();
+const tagCache = new Map();
 
 async function testConnection(settings: PluginSettings) {
 	new Notice("Testing connection to " + settings.paperlessUrl)
@@ -118,7 +118,7 @@ async function refreshCacheFromPaperless(settings: PluginSettings, silent=true) 
 		}
 	})
 	for (let i = 0; i < tagResult.json['results'].length; i++) {
-		let current = tagResult.json['results'][i];
+		const current = tagResult.json['results'][i];
 		tagCache.set(current['id'], current);
 	}
 	if(!silent) {
@@ -204,7 +204,7 @@ async function getExistingShareLink(settings: PluginSettings, documentId: string
 			console.error("An exception occurred in getExistingShareLink. Response: " + result);
 			return null;
 		}
-		for (let item of result.json) {
+		for (const item of result.json) {
 			if (item['expiration'] == null)  {
 				return new URL(settings.paperlessUrl + '/share/' + item['slug']);
 			}
@@ -395,7 +395,7 @@ class DocumentSelectorModal extends Modal {
 			}
 		})
 		imgElement.src = URL.createObjectURL(new Blob([result.arrayBuffer]));
-	};
+	}
 
 	async displayTags(tagDiv: HTMLDivElement, documentId: string) {
 		const thumbUrl = this.settings.paperlessUrl + '/api/documents/' + documentId + '/';
@@ -413,7 +413,7 @@ class DocumentSelectorModal extends Modal {
 			tagStr.setCssStyles({color: tagData['text_color'], fontSize: '0.7em'});
 			currentTag.setCssStyles({background: tagData['color'], borderRadius: '8px', padding: '2px', marginTop: '1px', marginRight: '5px'})
 		}
-	};
+	}
 
 	async onOpen() {
 		const {contentEl} = this;
@@ -514,7 +514,7 @@ class DocumentSelectorModal extends Modal {
 		};
 
 		const totalWidth = contentEl.innerWidth;
-		this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:String, b:String) => {return +a - +b}).reverse();
+		this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:string, b:string) => {return +a - +b}).reverse();
 		const totalAssets = this.availableDocumentIds.length;
 
 		// Create scroll container
@@ -545,7 +545,7 @@ class DocumentSelectorModal extends Modal {
 
 			if (searchQuery === '' && this.selectedTags.size === 0) {
 				// Reset to cached results
-				this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:String, b:String) => {return +a - +b}).reverse();
+				this.availableDocumentIds = cachedResult.json['results'].map((d: Record<string, any>) => d.id.toString()).sort((a:string, b:string) => {return +a - +b}).reverse();
 			} else {
 				// Perform search
 				searchInput.disabled = true;
@@ -555,7 +555,7 @@ class DocumentSelectorModal extends Modal {
 				try {
 					const tagIds = Array.from(this.selectedTags);
 					const searchResults = await searchPaperlessDocuments(this.settings, searchQuery, tagIds);
-					this.availableDocumentIds = searchResults.sort((a:String, b:String) => {return +a - +b}).reverse();
+					this.availableDocumentIds = searchResults.sort((a:string, b:string) => {return +a - +b}).reverse();
 				} catch (error) {
 					new Notice('Failed to search documents');
 					console.error('Search failed:', error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -835,9 +835,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -907,9 +907,9 @@
 			"peer": true
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1004,9 +1004,9 @@
 			"peer": true
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
@@ -1480,9 +1480,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true
@@ -1709,10 +1709,20 @@
 			"peer": true
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -1790,9 +1800,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -1828,9 +1838,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"dev": true,
 			"license": "ISC",
 			"peer": true,
@@ -2003,9 +2013,9 @@
 			}
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {


### PR DESCRIPTION
## Summary

This PR improves document importing and keeps the existing PDF++ workflow intact.

### Changes

- Preserve PDF++ dummy PDF files containing Paperless share URLs.
- Avoid downloading PDF binaries into the Obsidian vault.
- Handle empty and leading-slash storage paths as vault-relative paths.
- Replace editor links only after successful file creation.
- Add per-document error handling for bulk imports.
- Add archive and original share-link fallback handling.
- Filter share links by `file_version` and expiration.
- Add delayed retries for newly created share links.
- Handle pagination for documents, tags, searches, and share links.
- Use the current Paperless `text` search parameter.
- Prevent stale asynchronous search responses from overwriting newer results.
- Reset the modal loading state correctly after refreshes.
- Preserve the existing source comments and formatting.
- Update the README with the new command and settings.
- Refresh locked dependencies to remove the production lodash vulnerability.

## Testing

- `npm ci --ignore-scripts`
- `npm run build`
- `npm audit --omit=dev`
- `git diff --check`

All checks pass.

## Manual testing

Please verify the following with a live Paperless-ngx instance:

- Insert a document as an embedded PDF.
- Insert a document as a normal link.
- Use an empty document storage path.
- Use a custom document storage path.
- Import missing document references.
- Use documents with archive and original versions.
- Use documents without an archive version.
- Search through multiple pages of documents.
- Use more tags than fit on the first API page.
- Test missing or unavailable share links.
- Refresh the document selector while documents are loading.

This PR supersedes the earlier closed implementation in PR #29.